### PR TITLE
Broaden Continuous Integration Workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,17 +5,17 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,16 +26,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r requirements-dev.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with pytest and report coverage
       run: |
         cd tests
-        pytest
+        coverage run -m pytest
+        coverage report -m
         cd ..

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# macOS
+*.DS_Store

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,7 @@ numpy
 pandas
 python-dateutil
 requests
+requests-mock
+coverage
+pytest
+flake8


### PR DESCRIPTION
### Proposed Changes to the Continuous Integration Workflow
As Python 3.10 is now the current version of Python, I think it makes sense to update the continuous integration workflow to include recent versions such as 3.9 and 3.10 (especially as the deployment to pypi uses the latest version of Python). While editing the workflow `.yml` I thought it might be reasonable to also test other OS beyond Ubuntu as GitHub Actions supports MacOS and Windows as well. While running the tests, we can also generate test coverage and have it print to the Actions console in the event one ever wants to see what is being covered and what isn't. As GitHub Actions on public repositories is currently not subject to any quotas or limits, I also removed the restriction which only ran the CI workflow when pushing or pulling to the "master" branch. Seems like it could help individual contributors to see whether or not their changes are breaking the CI workflow before opening a PR.

The other change I made involved minor alterations to the `requirements.txt` file. Specifically, versions were unpinned (which doesn't seem to create any new test failures), and "developer dependencies" (flake8, pytest, etc) were separated into a `requirements-dev.txt` file. I think this will enable users to install from source with just the minimal dependencies needed to use the package, while developers can install from source with the additional packages needed to run the tests or the linter.

### Fragile/Failing Tests on MacOS
It does seem like the MacOS build is more fragile for some reason. Sometimes the tests pass, and other times they do not, whereas they seem to more consistently pass on Ubuntu. Specifically, it is the `nwis_test.py::test_iv_service()` test, and associated answer checking test, that seem to fail when submitting a query with multiple sites. 

### Future Development of Documentation
There was a requirement for `sphinx` tucked in the `requirements.txt` file. I'm going to hazard a guess and figure there is a desire for sphinx-based HTML documentation? If so that's something I can put together relatively quickly and it could be hosted via GitHub Pages -- let me know if that is a direction you want to move in. 