### PR TITLE
warnings for qwdata deprecation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -73,6 +73,7 @@ def get_qwdata(datetime_index=True, wide_format=True, sites=None,
         The NWIS qw data service is being deprecated. See this note from the
         R package for more information:
         https://cran.r-project.org/web/packages/dataRetrieval/vignettes/qwdata_changes.html
+        If you have additional questions about the qw data service, email gs-w-IOW_PO_team@usgs.gov.
 
     Parameters
     ----------

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -12,6 +12,7 @@
 
 """
 
+import warnings
 import pandas as pd
 from io import StringIO
 import re
@@ -66,6 +67,12 @@ def get_qwdata(datetime_index=True, wide_format=True, sites=None,
                start=None, end=None, multi_index=True,**kwargs):
     """
     Get water sample data from qwdata service.
+
+    .. warning::
+
+        The NWIS qw data service is being deprecated. See this note from the
+        R package for more information:
+        https://cran.r-project.org/web/packages/dataRetrieval/vignettes/qwdata_changes.html
 
     Parameters
     ----------
@@ -128,6 +135,11 @@ def _qwdata(datetime_index=True, **kwargs):
     #kwargs = {**payload, **kwargs}
     kwargs.update(payload)
 
+    warnings.warn(
+        "NWIS qw web services are being retired. " +
+        "See this note from the R package for more: " +
+        "https://cran.r-project.org/web/packages/dataRetrieval/vignettes/qwdata_changes.html",
+        category=DeprecationWarning)
     response = query_waterdata('qwdata', **kwargs)
 
     df = _read_rdb(response.text)


### PR DESCRIPTION
- adds deprecation warnings to calls to the qwdata service as well as a warning in the documentation
- drops CI support for python 3.6 as it is no longer included in the "ubuntu-latest" image (hence the failing CI build)

@lstanish-usgs this is the extent of where we would place warnings for this deprecation - feel free to propose changes to the wording.
