### PR TITLE
add ability to coerce incomplete datetime info + tests

### DIFF
--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -240,7 +240,9 @@ def _gwlevels(**kwargs):
     response = query_waterservices('gwlevels', **kwargs)
 
     df = _read_rdb(response.text)
-    df = format_datetime(df, 'lev_dt', 'lev_tm', 'lev_tz_cd')
+
+    coerce_datetime = kwargs.pop('coerce_datetime', False)
+    df = format_datetime(df, 'lev_dt', 'lev_tm', 'lev_tz_cd', coerce_datetime)
 
     return format_response(df, **kwargs), _set_metadata(response, **kwargs)
 

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -63,8 +63,9 @@ def preformat_peaks_response(df):
     return df
 
 
-def get_qwdata(datetime_index=True, wide_format=True, sites=None,
-               start=None, end=None, multi_index=True,**kwargs):
+def get_qwdata(sites=None, start=None, end=None,
+               multi_index=True, wide_format=True, datetime_index=True,
+               **kwargs):
     """
     Get water sample data from qwdata service.
 
@@ -77,10 +78,6 @@ def get_qwdata(datetime_index=True, wide_format=True, sites=None,
 
     Parameters
     ----------
-    datetime_index : boolean
-        If True, create a datetime index
-    wide_format : boolean
-        If True, return data in wide format with multiple samples per row and one row per time.
     sites: array of strings
         If the qwdata parameter site_no is supplied, it will overwrite the sites parameter
     start: string
@@ -89,6 +86,10 @@ def get_qwdata(datetime_index=True, wide_format=True, sites=None,
         If the qwdata parameter end_date is supplied, it will overwrite the end parameter
     multi_index: boolean
         If False, a dataframe with a single-level index (datetime) is returned
+    wide_format : boolean
+        If True, return data in wide format with multiple samples per row and one row per time
+    datetime_index : boolean
+        If True, create a datetime index
     **kwargs: optional
         If supplied, will be used as query parameters
 
@@ -100,8 +101,10 @@ def get_qwdata(datetime_index=True, wide_format=True, sites=None,
     start = kwargs.pop('begin_date', start)
     end = kwargs.pop('end_date', end)
     sites = kwargs.pop('site_no', sites)
-    return _qwdata(site_no=sites, begin_date=start, end_date=end, datetime_index=datetime_index,
-                   multi_index=multi_index, ** kwargs)
+    return _qwdata(site_no=sites, begin_date=start, end_date=end,
+                   datetime_index=datetime_index,
+                   multi_index=multi_index, **kwargs)
+
 
 def _qwdata(datetime_index=True, **kwargs):
     # check number of sites, may need to create multiindex
@@ -181,7 +184,8 @@ def _discharge_measurements(**kwargs):
     return _read_rdb(response.text), _set_metadata(response, **kwargs)
 
 
-def get_discharge_peaks(sites=None, start=None, end=None,  multi_index=True, **kwargs):
+def get_discharge_peaks(sites=None, start=None, end=None,
+                        multi_index=True, **kwargs):
     """
     Get discharge peaks from the waterdata service.
 
@@ -193,6 +197,8 @@ def get_discharge_peaks(sites=None, start=None, end=None,  multi_index=True, **k
         If the waterdata parameter begin_date is supplied, it will overwrite the start parameter
     end: string
         If the waterdata parameter end_date is supplied, it will overwrite the end parameter
+    multi_index: boolean
+        If False, a dataframe with a single-level index (datetime) is returned
     **kwargs: optional
         If supplied, will be used as query parameters
 
@@ -202,7 +208,8 @@ def get_discharge_peaks(sites=None, start=None, end=None,  multi_index=True, **k
     start = kwargs.pop('begin_date', start)
     end = kwargs.pop('end_date', end)
     sites = kwargs.pop('site_no', sites)
-    return _discharge_peaks(site_no=sites, begin_date=start, end_date=end, multi_index=multi_index, **kwargs)
+    return _discharge_peaks(site_no=sites, begin_date=start, end_date=end,
+                            multi_index=multi_index, **kwargs)
 
 
 def _discharge_peaks(**kwargs):
@@ -213,7 +220,8 @@ def _discharge_peaks(**kwargs):
     return format_response(df, service='peaks', **kwargs), _set_metadata(response, **kwargs)
 
 
-def get_gwlevels(start='1851-01-01', end=None, multi_index=True, **kwargs):
+def get_gwlevels(sites=None, start='1851-01-01', end=None,
+                 multi_index=True, datetime_index=True, **kwargs):
     """
     Queries the groundwater level service from waterservices
 
@@ -224,6 +232,10 @@ def get_gwlevels(start='1851-01-01', end=None, multi_index=True, **kwargs):
         parameter (defaults to '1851-01-01')
     end: string
         If the waterdata parameter end_date is supplied, it will overwrite the end parameter
+    multi_index: boolean
+        If False, a dataframe with a single-level index (datetime) is returned
+    datetime_index : boolean
+        If True, create a datetime index
     **kwargs: optional
         If supplied, will be used as query parameters
 
@@ -232,17 +244,20 @@ def get_gwlevels(start='1851-01-01', end=None, multi_index=True, **kwargs):
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
-    return _gwlevels(startDT=start, endDT=end, multi_index=multi_index, **kwargs)
+    sites = kwargs.pop('sites', sites)
+    return _gwlevels(startDT=start, endDT=end,
+                     datetime_index=datetime_index, sites=sites,
+                     multi_index=multi_index, **kwargs)
 
 
-def _gwlevels(**kwargs):
+def _gwlevels(datetime_index=True, **kwargs):
 
     response = query_waterservices('gwlevels', **kwargs)
 
     df = _read_rdb(response.text)
 
-    coerce_datetime = kwargs.pop('coerce_datetime', False)
-    df = format_datetime(df, 'lev_dt', 'lev_tm', 'lev_tz_cd', coerce_datetime)
+    if datetime_index == True:
+        df = format_datetime(df, 'lev_dt', 'lev_tm', 'lev_tz_cd')
 
     return format_response(df, **kwargs), _set_metadata(response, **kwargs)
 
@@ -334,7 +349,7 @@ def query_waterservices(service, **kwargs):
     return query(url, payload=kwargs)
 
 
-def get_dv(start=None, end=None, multi_index=True, **kwargs):
+def get_dv(sites=None, start=None, end=None, multi_index=True, **kwargs):
     """
     Get daily values data from NWIS and return it as a ``pandas.DataFrame``.
 
@@ -354,7 +369,9 @@ def get_dv(start=None, end=None, multi_index=True, **kwargs):
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
-    return _dv(startDT=start, endDT=end, multi_index=multi_index, **kwargs)
+    sites = kwargs.pop('sites', sites)
+    return _dv(startDT=start, endDT=end, sites=sites,
+               multi_index=multi_index, **kwargs)
 
 
 def _dv(**kwargs):
@@ -373,7 +390,7 @@ def get_info(**kwargs):
     Parameters
     ----------
     sites : string or list
-        A list of site numters. Sites may be prefixed with an optional agency
+        A list of site numbers. Sites may be prefixed with an optional agency
         code followed by a colon.
 
     stateCd : string
@@ -455,7 +472,7 @@ def get_info(**kwargs):
     return _read_rdb(response.text), _set_metadata(response, **kwargs)
 
 
-def get_iv(start=None, end=None, multi_index=True, **kwargs):
+def get_iv(sites=None, start=None, end=None, multi_index=True, **kwargs):
     """Get instantaneous values data from NWIS and return it as a DataFrame.
 
     Note: If no start or end date are provided, only the most recent record is returned.
@@ -472,7 +489,9 @@ def get_iv(start=None, end=None, multi_index=True, **kwargs):
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
-    return _iv(startDT=start, endDT=end, multi_index=multi_index, **kwargs)
+    sites = kwargs.pop('sites', sites)
+    return _iv(startDT=start, endDT=end, sites=sites,
+               multi_index=multi_index, **kwargs)
 
 
 def _iv(**kwargs):
@@ -481,7 +500,7 @@ def _iv(**kwargs):
     return format_response(df, **kwargs), _set_metadata(response, **kwargs)
 
 
-def get_pmcodes(parameterCd = 'All', partial = True):
+def get_pmcodes(parameterCd='All', partial=True):
     """
     Return a ``pandas.DataFrame`` containing all NWIS parameter codes.
 
@@ -623,8 +642,9 @@ def what_sites(**kwargs):
     return df, _set_metadata(response, **kwargs)
 
 
-def get_record(sites=None, start=None, end=None, state=None,
-               service='iv', *args, **kwargs):
+def get_record(sites=None, start=None, end=None,
+               multi_index=True, wide_format=True, datetime_index=True,
+               state=None, service='iv', **kwargs):
     """
     Get data from NWIS and return it as a ``pandas.DataFrame``.
 
@@ -656,16 +676,19 @@ def get_record(sites=None, start=None, end=None, state=None,
         raise TypeError('Unrecognized service: {}'.format(service))
 
     if service == 'iv':
-        df, _ = get_iv(sites=sites, startDT=start, endDT=end, **kwargs)
+        df, _ = get_iv(sites=sites, startDT=start, endDT=end,
+                       multi_index=multi_index, **kwargs)
         return df
 
     elif service == 'dv':
-        df, _ = get_dv(sites=sites, startDT=start, endDT=end, **kwargs)
+        df, _ = get_dv(sites=sites, startDT=start, endDT=end,
+                       multi_index=multi_index, **kwargs)
         return df
 
     elif service == 'qwdata':
         df, _ = get_qwdata(site_no=sites, begin_date=start, end_date=end,
-                           qw_sample_wide='separated_wide', **kwargs)
+                           multi_index=multi_index,
+                           wide_format=wide_format, **kwargs)
         return df
 
     elif service == 'site':
@@ -679,12 +702,14 @@ def get_record(sites=None, start=None, end=None, state=None,
 
     elif service == 'peaks':
         df, _ = get_discharge_peaks(site_no=sites, begin_date=start,
-                                    end_date=end, **kwargs)
+                                    end_date=end,
+                                    multi_index=multi_index, **kwargs)
         return df
 
     elif service == 'gwlevels':
         df, _ = get_gwlevels(sites=sites, startDT=start, endDT=end,
-                             **kwargs)
+                             multi_index=multi_index,
+                             datetime_index=datetime_index, **kwargs)
         return df
 
     elif service == 'pmcodes':
@@ -696,7 +721,7 @@ def get_record(sites=None, start=None, end=None, state=None,
         return df
 
     elif service == 'ratings':
-        df, _ = get_ratings(**kwargs)
+        df, _ = get_ratings(site=sites, **kwargs)
         return df
 
     else:
@@ -790,8 +815,8 @@ def _read_rdb(rdb):
             break
 
     fields = re.split("[\t]", rdb.splitlines()[count])
-    fields  = [field.replace(",", "") for field in fields]
-    dtypes = {'site_no': str, 'dec_long_va': float, 'dec_lat_va': float, 'parm_cd': str, 'parameter_cd':str}
+    fields = [field.replace(",", "") for field in fields]
+    dtypes = {'site_no': str, 'dec_long_va': float, 'dec_lat_va': float, 'parm_cd': str, 'parameter_cd': str}
 
     df = pd.read_csv(StringIO(rdb), delimiter='\t', skiprows=count + 2,
                      names=fields, na_values='NaN', dtype=dtypes)

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -1,6 +1,7 @@
 """
 Useful utilities for data munging.
 """
+import numpy as np
 import pandas as pd
 import requests
 from dataretrieval.codes import tz
@@ -26,7 +27,7 @@ def to_str(listlike, delimiter=','):
         return listlike
 
 
-def format_datetime(df, date_field, time_field, tz_field):
+def format_datetime(df, date_field, time_field, tz_field, coerce_datetime=False):
     """Creates a datetime field from separate date, time, and
     time zone fields.
 
@@ -46,12 +47,19 @@ def format_datetime(df, date_field, time_field, tz_field):
     tz_field : string
         Name of time zone column in df.
 
+    coerce_datetime : boolean, optional
+        Optional boolean parameter to enable coercion of incomplete datetime
+        information into full datetime objects. Default is False, meaning
+        incomplete datetimes will be designated NaT. If set to True, then
+        missing months, days, or times will be replaced by 01, 01, and
+        00:00:00+00:00 respectively.
+
     Returns
     -------
     df : ``pandas.DataFrame``
     """
 
-    #create a datetime index from the columns in qwdata response
+    # create a datetime index from the columns in qwdata response
     df[tz_field] = df[tz_field].map(tz)
 
     df['datetime'] = pd.to_datetime(df[date_field] + ' ' +
@@ -60,7 +68,25 @@ def format_datetime(df, date_field, time_field, tz_field):
                                     format = '%Y-%m-%d %H:%M',
                                     utc=True)
 
+    # if there are any incomplete dates, call corresponding private function
+    if any(pd.isna(df['datetime']) == True) and coerce_datetime is True:
+        df['datetime'] = _format_incomplete_dates(df,
+                                                  date_field,
+                                                  time_field,
+                                                  tz_field)
+
     return df
+
+
+def _format_incomplete_dates(df, date_field, time_field, tz_field):
+    # get indices with incomplete datetime information
+    idx = np.where(pd.isna(df['datetime']) == True)
+    for i in idx:
+        # re-make without the time bit
+        df.loc[i, 'datetime'] = pd.to_datetime(df[date_field][i],
+                                               format='%Y-%m-%d',
+                                               utc=True)
+    return df['datetime']
 
 
 #This function may be deprecated once pandas.update support joins besides left.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dataretrieval',
-      version='0.7',
+      version='0.8',
       description='',
       url='',
       author='Timothy Hodson',

--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -31,7 +31,7 @@ def test_iv_service():
     start = START_DATE
     end   = END_DATE
     service = 'iv'
-    site = ['03339000','05447500','03346500']
+    site = ['03339000', '05447500', '03346500']
     return get_record(site, start, end, service=service)
 
 def test_iv_service_answer():
@@ -70,34 +70,55 @@ if __name__=='__main__':
 def test_inc_date_01():
     """Test based on GitHub Issue #47 - lack of timestamp for measurement."""
     site = "403451073585601"
-    df = get_record(site, "1980-01-01", "1990-01-01", service='gwlevels')
+    # make call expecting a warning to be thrown due to incomplete dates
+    with pytest.warns(UserWarning):
+        df = get_record(site, "1980-01-01", "1990-01-01", service='gwlevels')
     # assert that there are indeed incomplete dates
     assert any(pd.isna(df.index) == True)
-    # make call with date coersion then assert lack of incomplete dates
-    df = get_record(site, "1980-01-01", "1990-01-01", service='gwlevels',
-                    coerce_datetime=True)
-    assert all(pd.isna(df.index) == False)
+    # assert that the datetime index is there
+    assert df.index.name == 'datetime'
+    # make call without defining a datetime index and check that it isn't there
+    df2 = get_record(site, "1980-01-01", "1990-01-01", service='gwlevels',
+                     datetime_index=False)
+    # assert shape of both dataframes is the same (contain the same data)
+    assert df.shape == df2.shape
+    # assert that the datetime index is not there
+    assert df2.index.name != 'datetime'
 
 
 def test_inc_date_02():
     """Test based on GitHub Issue #47 - lack of month, day, or time."""
     site = "180049066381200"
-    df = get_record(site, "1900-01-01", "2013-01-01", service='gwlevels')
+    # make call expecting a warning to be thrown due to incomplete dates
+    with pytest.warns(UserWarning):
+        df = get_record(site, "1900-01-01", "2013-01-01", service='gwlevels')
     # assert that there are indeed incomplete dates
     assert any(pd.isna(df.index) == True)
-    # make call with date coersion then assert lack of incomplete dates
-    df = get_record(site, "1900-01-01", "2013-01-01", service='gwlevels',
-                    coerce_datetime=True)
-    assert all(pd.isna(df.index) == False)
+    # assert that the datetime index is there
+    assert df.index.name == 'datetime'
+    # make call without defining a datetime index and check that it isn't there
+    df2 = get_record(site, "1900-01-01", "2013-01-01", service='gwlevels',
+                     datetime_index=False)
+    # assert shape of both dataframes is the same (contain the same data)
+    assert df.shape == df2.shape
+    # assert that the datetime index is not there
+    assert df2.index.name != 'datetime'
 
 
 def test_inc_date_03():
     """Test based on GitHub Issue #47 - lack of day, and times."""
     site = "290000095192602"
-    df = get_record(site, "1975-01-01", "2000-01-01", service='gwlevels')
+    # make call expecting a warning to be thrown due to incomplete dates
+    with pytest.warns(UserWarning):
+        df = get_record(site, "1975-01-01", "2000-01-01", service='gwlevels')
     # assert that there are indeed incomplete dates
     assert any(pd.isna(df.index) == True)
-    # make call with date coersion then assert lack of incomplete dates
-    df = get_record(site, "1975-01-01", "2000-01-01", service='gwlevels',
-                    coerce_datetime=True)
-    assert all(pd.isna(df.index) == False)
+    # assert that the datetime index is there
+    assert df.index.name == 'datetime'
+    # make call without defining a datetime index and check that it isn't there
+    df2 = get_record(site, "1975-01-01", "2000-01-01", service='gwlevels',
+                     datetime_index=False)
+    # assert shape of both dataframes is the same (contain the same data)
+    assert df.shape == df2.shape
+    # assert that the datetime index is not there
+    assert df2.index.name != 'datetime'

--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -61,3 +61,43 @@ def test_preformat_peaks_response():
 if __name__=='__main__':
      test_measurements_service_answer()
      test_iv_service_answer()
+
+
+# tests using real queries to USGS webservices
+# these specific queries represent some edge-cases and the tests to address
+# incomplete date-time information
+
+def test_inc_date_01():
+    """Test based on GitHub Issue #47 - lack of timestamp for measurement."""
+    site = "403451073585601"
+    df = get_record(site, "1980-01-01", "1990-01-01", service='gwlevels')
+    # assert that there are indeed incomplete dates
+    assert any(pd.isna(df.index) == True)
+    # make call with date coersion then assert lack of incomplete dates
+    df = get_record(site, "1980-01-01", "1990-01-01", service='gwlevels',
+                    coerce_datetime=True)
+    assert all(pd.isna(df.index) == False)
+
+
+def test_inc_date_02():
+    """Test based on GitHub Issue #47 - lack of month, day, or time."""
+    site = "180049066381200"
+    df = get_record(site, "1900-01-01", "2013-01-01", service='gwlevels')
+    # assert that there are indeed incomplete dates
+    assert any(pd.isna(df.index) == True)
+    # make call with date coersion then assert lack of incomplete dates
+    df = get_record(site, "1900-01-01", "2013-01-01", service='gwlevels',
+                    coerce_datetime=True)
+    assert all(pd.isna(df.index) == False)
+
+
+def test_inc_date_03():
+    """Test based on GitHub Issue #47 - lack of day, and times."""
+    site = "290000095192602"
+    df = get_record(site, "1975-01-01", "2000-01-01", service='gwlevels')
+    # assert that there are indeed incomplete dates
+    assert any(pd.isna(df.index) == True)
+    # make call with date coersion then assert lack of incomplete dates
+    df = get_record(site, "1975-01-01", "2000-01-01", service='gwlevels',
+                    coerce_datetime=True)
+    assert all(pd.isna(df.index) == False)

--- a/tests/waterservices_test.py
+++ b/tests/waterservices_test.py
@@ -119,7 +119,8 @@ def test_get_qwdata(requests_mock):
                   '&date_format=YYYY-MM-DD&rdb_compression=value&submmitted_form=brief_list'.format(site, format)
     response_file_path = 'data/waterdata_qwdata.txt'
     mock_request(requests_mock, request_url, response_file_path)
-    df, md = get_qwdata(sites=["01491000", "01645000"])
+    with pytest.warns(DeprecationWarning):
+        df, md = get_qwdata(sites=["01491000", "01645000"])
     assert type(df) is DataFrame
     assert df.size == 1821472
     assert_metadata(requests_mock, request_url, md, site, None, format)
@@ -279,7 +280,7 @@ def assert_metadata(requests_mock, request_url, md, site, parameter_cd, format):
         site_info, _ = md.site_info()
         assert type(site_info) is DataFrame
     if parameter_cd is None:
-        assert md.variable_info is None    
+        assert md.variable_info is None
     else:
         for param in parameter_cd:
             pcode_request_url = "https://help.waterdata.usgs.gov/code/parameter_cd_nm_query?fmt=rdb&parm_nm_cd=%25{}%25".format(param)
@@ -287,9 +288,8 @@ def assert_metadata(requests_mock, request_url, md, site, parameter_cd, format):
                 requests_mock.get(pcode_request_url, text=text.read())
         variable_info, _ = md.variable_info()
         assert type(variable_info) is DataFrame
-        
+
     if format == "rdb":
         assert md.comment is not None
     else:
         assert md.comment is None
-


### PR DESCRIPTION
This PR is designed to close #47.

**This PR does not change current default functionality**

### Problem Summary

The gist of the problem (as I understood it) is that some groundwater data records lack full date-time information. Sometimes the timestamp is missing, or even the month or day is not provided. The current approach to creating `pandas` datetime objects assumes all of that information is known, and if not, creates the equivalent of a `NaN` entry (`NaT`). This is fundamentally a conservative solution, as no datetime information is provided when it is incomplete; the user can always look at the original columns (`lev_dt`, `lev_tm`, `lev_tz_cd`) if they wanted to dig into the available partial data or construct their own index/ordering for the data frame. *The existing implementation could be the final implementation* - the burden of handling atypical or incomplete date-times could be left to the user.

<s>
### Proposed Solution

A number of people have had issues with the existing approach, however, hence the creation of issue #47 and comments within it. One potential resolution is provided in this PR. Effectively this PR proposes:

1. Creation of an optional key-word argument `coerce_datetime` that is False by default, but can be input as True
2. If True, incomplete dates are coerced into complete `pandas` datetime objects. **This coercion sets any missing value to 0** - for example if no time information is available, the time assigned is 00:00:00+00:00
3. If False (default behavior) the function works as it currently does, and incomplete dates are set as `NaT` 

This PR adds 3 unit tests using 3 groundwater sites with incomplete information. The test are simple, first they confirm that the default behavior results in `NaT` data frame index values. Next they use the optional coercion functionality, and confirm that the new output has no `NaT` index values.


The suggestion by @SarkenD in issue #47 to have a separate date and time column, is (somewhat) already present by default. The `lev_dt` column provides date information, and the `lev_tm` and `lev_tz_cd` provide time information for each measurement. The current practice of creating a combined datetime index for the data frames was not something I wanted to change, especially as it seems to make sense and work for the vast majority of cases. This optional method gives users a way to *force* their data to have complete datetimes. Due to the loss of timestamp integrity, this functionality should not be the default. To me the real question is: **Should this optional date-time coercion even be provided as an option?**
</s>

### Revised Solution

Follows @thodson-usgs's proposed standardized approach below:

- default behavior is to parse datetimes and use them to set the index (`datetime_index=True`)
- if there are `NaT` datetime values, their count is provided as a warning and it is suggested that the parameter be switched to `datetime_index=False`
- When `datetime_index=False` then the indexing is simply by integers (i.e. no datetime formatting is done)

To further standardize the different service functions, the order of parameters was made more consistent and is now - sites, start, end, multi_index, wide_format, datetime_index, **kwargs - as relevant for the individual functions.

This standardization impacted some functions, including `get_qwdata`, `get_gwlevels`, `get_dv` and `get_iv`. Consequently, this  has the potential to change function behavior in two ways:
1. Prior function calls where argument names were not supplied and the order of arguments was used may be different from the proposed (standardized) order of function arguments
2. Conversely, new function arguments, for example, the addition of the argument `sites` to `get_iv`, make it so that a function call made with the revised code might not work using the existing code - `get_iv(siteno, start, end)` would work with proposed changes, but would not have previously worked without naming the arguments because `get_iv` does not currently expect the first argument to be the site numbers

Ultimately, the proposed changes did not break any of the existing unit tests. But because of the potential impacts to workflows identified above, I incremented the minor version of the package. 