### PR TITLE
Better 414 Response Error Message

### DIFF
--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -167,6 +167,8 @@ def query(url, payload, delimiter=','):
 
     if response.status_code == 400:
         raise ValueError("Bad Request, check that your parameters are correct. URL: {}".format(response.url))
+    elif response.status_code == 414:
+        raise ValueError("Request URL too long. Modify your query to use fewer sites. API response reason: {}".format(response.reason))
 
     if response.text.startswith('No sites/data'):
         raise NoSitesError(response.url)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,21 @@
+"""Unit tests for functions in utils.py"""
+import pytest
+from dataretrieval import utils
+import dataretrieval.nwis as nwis
+
+
+class Test_query:
+    """Tests of the query function."""
+
+    def test_url_too_long(self):
+        """Test to confirm more useful error when query URL too long.
+
+        Test based on GitHub Issue #64
+        """
+        # all sites in MD
+        sites, _ = nwis.what_sites(stateCd='MD')
+        # expected error message
+        _msg = "Request URL too long. Modify your query to use fewer sites. API response reason: Request-URI Too Long"
+        # raise error by trying to query them all, so URL is way too long
+        with pytest.raises(ValueError, match=_msg):
+            nwis.get_iv(sites=sites.site_no.values.tolist())


### PR DESCRIPTION
This PR closes #64. 

It is pretty straightforward, we handle the 414 response case in `query()` and print out a custom error message to convey to the user that the API query generated by their function call is too long. Previous error message was not useful to the end-user, per #64.

This PR also adds a corresponding unit test which checks that both the expected error type and message are captured when trying to perform a query with a URL that is too long.