### PR TITLE
Fix to enable seriesCatalogOutput

### DIFF
--- a/dataretrieval/codes/states.py
+++ b/dataretrieval/codes/states.py
@@ -5,7 +5,7 @@ state_codes =[
     'ar', # Arkansas
     'ca', # California
     'co', # Colorado
-    'ct', # Conneticut
+    'ct', # Connecticut
     'de', # Delaware
     'dc', # District of Columbia
     'fl', # Florida

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -455,17 +455,23 @@ def get_info(**kwargs):
         siteOutput=expanded cannot be used if seriesCatalogOutput=true or with
         any values for outputDataTypeCd.
 
-    seriesCatalogOutput : boolean
+    seriesCatalogOutput : boolean or string
         A switch that provides detailed period of record information for
         certain output formats. The period of record indicates date ranges for
         a certain kind of information about a site, for example the start and
-        end dates for a site's daily mean streamflow.
+        end dates for a site's daily mean streamflow. Can be set as True,
+        'True', 'TRUE', or 'true'.
 
     For additional parameter options see
     https://waterservices.usgs.gov/rest/Site-Service.html#stateCd
     """
-
-    kwargs['siteOutput'] = 'Expanded'
+    seriesCatalogOutput = kwargs.pop('seriesCatalogOutput', None)
+    if seriesCatalogOutput in ['True', 'TRUE', 'true', True]:
+        # convert bool to string if necessary
+        kwargs['seriesCatalogOutput'] = 'True'
+    else:
+        # cannot have both seriesCatalogOutput and the expanded format
+        kwargs['siteOutput'] = 'Expanded'
 
     response = query_waterservices('site', **kwargs)
 

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -455,12 +455,11 @@ def get_info(**kwargs):
         siteOutput=expanded cannot be used if seriesCatalogOutput=true or with
         any values for outputDataTypeCd.
 
-    seriesCatalogOutput : boolean or string
+    seriesCatalogOutput : boolean
         A switch that provides detailed period of record information for
         certain output formats. The period of record indicates date ranges for
         a certain kind of information about a site, for example the start and
-        end dates for a site's daily mean streamflow. Can be set as True,
-        'True', 'TRUE', or 'true'.
+        end dates for a site's daily mean streamflow.
 
     For additional parameter options see
     https://waterservices.usgs.gov/rest/Site-Service.html#stateCd

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -11,6 +11,7 @@ Simple uses of the ``dataretrieval`` package
     :maxdepth: 2
 
     readme_examples
+    siteinfo_examples
 
 Using ``dataretrieval`` to obtain nation trends in peak annual streamflow
 -------------------------------------------------------------------------

--- a/docs/source/examples/siteinfo_examples.rst
+++ b/docs/source/examples/siteinfo_examples.rst
@@ -1,0 +1,50 @@
+
+Retrieving site information
+---------------------------
+
+By default ``dataretrieval`` fetches the so-called "expanded" site date from
+the NWIS web service. However there is an optional keyword parameter called
+``seriesCatalogOutput`` that can be set to "True" if you wish to retrieve the
+detailed period of record information for a site instead. Refer to the
+`NWIS water services documentation`_ for additional information. The below
+example illustrates the use of the ``seriesCatalogOutput`` switch and displays
+the resulting column names for the output dataframes (example prompted by
+`GitHub Issue #34`_).
+
+.. _NWIS water services documentation: https://nwis.waterservices.usgs.gov/rest/Site-Service.html
+
+.. _GitHub Issue #34: https://github.com/USGS-python/dataretrieval/issues/34
+
+.. doctest::
+
+    # first import the functions for downloading data from NWIS
+    >>> import dataretrieval.nwis as nwis
+
+    # fetch data from a major HUC basin with seriesCatalogOutput set to True
+    >>> df = nwis.get_record(huc='20', parameterCd='00060',
+    ...                      service='site', seriesCatalogOutput='True')
+
+    >>> print(df.columns)
+    Index(['agency_cd', 'site_no', 'station_nm', 'site_tp_cd', 'dec_lat_va',
+           'dec_long_va', 'coord_acy_cd', 'dec_coord_datum_cd', 'alt_va',
+           'alt_acy_va', 'alt_datum_cd', 'huc_cd', 'data_type_cd', 'parm_cd',
+           'stat_cd', 'ts_id', 'loc_web_ds', 'medium_grp_cd', 'parm_grp_cd',
+           'srs_id', 'access_cd', 'begin_date', 'end_date', 'count_nu'],
+          dtype='object')
+
+    # repeat the same query with seriesCatalogOutput set as False
+    >>> df = nwis.get_record(huc='20', parameterCd='00060',
+    ...                      service='site', seriesCatalogOutput='False')
+
+    >>> print(df.columns)
+    Index(['agency_cd', 'site_no', 'station_nm', 'site_tp_cd', 'lat_va', 'long_va',
+           'dec_lat_va', 'dec_long_va', 'coord_meth_cd', 'coord_acy_cd',
+           'coord_datum_cd', 'dec_coord_datum_cd', 'district_cd', 'state_cd',
+           'county_cd', 'country_cd', 'land_net_ds', 'map_nm', 'map_scale_fc',
+           'alt_va', 'alt_meth_cd', 'alt_acy_va', 'alt_datum_cd', 'huc_cd',
+           'basin_cd', 'topo_cd', 'instruments_cd', 'construction_dt',
+           'inventory_dt', 'drain_area_va', 'contrib_drain_area_va', 'tz_cd',
+           'local_time_fg', 'reliability_cd', 'gw_file_cd', 'nat_aqfr_cd',
+           'aqfr_cd', 'aqfr_type_cd', 'well_depth_va', 'hole_depth_va',
+           'depth_src_cd', 'project_no'],
+          dtype='object')

--- a/docs/source/meta/contributing.rst
+++ b/docs/source/meta/contributing.rst
@@ -68,6 +68,22 @@ Before you submit a pull request, check that it meets these guidelines:
    Actions continuous integration pipelines.
 
 
+Updating Package Version:
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Follow semantic versioning as best as possible. This means that changing the
+first digit of the version indicates a breaking change. Any smaller changes
+should attempt to maintain backwards-compatibility with previous code and
+issue deprecation warnings for features or functionality that will be removed
+or no longer be backwards-compatible in future releases.
+
+When updating the package version, there are currently two places where this
+must be done:
+
+1. In the `setup.py` file the version field should be updated
+2. In the `conf.py` file both the version and release fields can be updated
+
+
 Coding Standards
 ----------------
 

--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import datetime
-from dataretrieval.nwis import get_record, preformat_peaks_response
+from dataretrieval.nwis import get_record, preformat_peaks_response, get_info
 from dataretrieval.nwis import what_sites, get_iv, get_dv, get_discharge_peaks
 
 START_DATE = '2018-01-24'
@@ -146,3 +146,51 @@ class TestTZ:
         assert 'datetime' in iv.index.names
         # assert that it is a datetime type
         assert isinstance(iv.index[0][1], datetime.datetime)
+
+
+class TestSiteseriesCatalogOutput:
+    """Tests relating to GitHub Issue #34."""
+
+    def test_seriesCatalogOutput_get_record(self):
+        """Test setting seriesCatalogOutput to true with get_record."""
+        data = get_record(huc='20', parameterCd='00060',
+                          service='site', seriesCatalogOutput='True')
+        # assert that expected data columns are present
+        assert 'begin_date' in data.columns
+        assert 'end_date' in data.columns
+        assert 'count_nu' in data.columns
+
+    def test_seriesCatalogOutput_get_info(self):
+        """Test setting seriesCatalogOutput to true with get_info."""
+        data, _ = get_info(
+            huc='20', parameterCd='00060', seriesCatalogOutput='TRUE')
+        # assert that expected data columns are present
+        assert 'begin_date' in data.columns
+        assert 'end_date' in data.columns
+        assert 'count_nu' in data.columns
+
+    def test_seriesCatalogOutput_bool(self):
+        """Test setting seriesCatalogOutput with a boolean."""
+        data, _ = get_info(
+            huc='20', parameterCd='00060', seriesCatalogOutput=True)
+        # assert that expected data columns are present
+        assert 'begin_date' in data.columns
+        assert 'end_date' in data.columns
+        assert 'count_nu' in data.columns
+
+    def test_expandedrdb_get_record(self):
+        """Test default expanded_rdb format with get_record."""
+        data = get_record(huc='20', parameterCd='00060',
+                          service='site', seriesCatalogOutput='False')
+        # assert that seriesCatalogOutput columns are not present
+        assert 'begin_date' not in data.columns
+        assert 'end_date' not in data.columns
+        assert 'count_nu' not in data.columns
+
+    def test_expandedrdb_get_info(self):
+        """Test default expanded_rdb format with get_info."""
+        data, _ = get_info(huc='20', parameterCd='00060')
+        # assert that seriesCatalogOutput columns are not present
+        assert 'begin_date' not in data.columns
+        assert 'end_date' not in data.columns
+        assert 'count_nu' not in data.columns


### PR DESCRIPTION
This PR closes #34.

Now in `get_info` the `kwargs` are checked for the `seriesCatalogOutput` parameter which, if true, is set in `kwargs` and the expanded rdb output is not requested. If `seriesCatalogOutput` is false or not present, then the expanded rdb output is requested -- so the default behavior of this function does not change.

Tests and an example in the documentation are added to show how this argument works.

Additional details surrounding the original problem are described in #34. 


A section in the documentation is added on updating the version numbers, which was prompted by #66 which still needs to be resolved.