### PR TITLE
Skip datetime handling for empty data frames

### DIFF
--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -800,7 +800,7 @@ def _read_json(json):
                                          on=['site_no', 'datetime'])
 
     # convert to datetime, normalizing the timezone to UTC when doing so
-    if merged_df.empty is False:
+    if 'datetime' in merged_df.columns:
         merged_df['datetime'] = pd.to_datetime(merged_df['datetime'], utc=True)
 
     return merged_df

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -800,7 +800,8 @@ def _read_json(json):
                                          on=['site_no', 'datetime'])
 
     # convert to datetime, normalizing the timezone to UTC when doing so
-    merged_df['datetime'] = pd.to_datetime(merged_df['datetime'], utc=True)
+    if merged_df.empty is False:
+        merged_df['datetime'] = pd.to_datetime(merged_df['datetime'], utc=True)
 
     return merged_df
 

--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -194,3 +194,10 @@ class TestSiteseriesCatalogOutput:
         assert 'begin_date' not in data.columns
         assert 'end_date' not in data.columns
         assert 'count_nu' not in data.columns
+
+
+def test_empty_timeseries():
+    """Test based on empty case from GitHub Issue #26."""
+    df = get_record(sites='011277906', service='iv',
+                    start='2010-07-20', end='2010-07-21')
+    assert df.empty is True

--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -199,5 +199,5 @@ class TestSiteseriesCatalogOutput:
 def test_empty_timeseries():
     """Test based on empty case from GitHub Issue #26."""
     df = get_record(sites='011277906', service='iv',
-                    start='2010-07-20', end='2010-07-21')
+                    start='2010-07-20', end='2010-07-20')
     assert df.empty is True


### PR DESCRIPTION
Looking into issue #26 revealed that recent changes to the datetime handling missed the case when the data frame is empty, instead a non-intuitive error message was delivered:

```
>>> df = nwis.get_record(sites='011277906', service='iv', start='2010-07-20', end='2010-07-20')
Traceback (most recent call last):
  File "/Users/jhariharan/mambaforge/envs/dataretrieval/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3800, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 138, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 165, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 5745, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 5753, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'datetime'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jhariharan/Documents/dataretrieval-1/dataretrieval/nwis.py", line 684, in get_record
    df, _ = get_iv(sites=sites, startDT=start, endDT=end,
  File "/Users/jhariharan/Documents/dataretrieval-1/dataretrieval/nwis.py", line 498, in get_iv
    return _iv(startDT=start, endDT=end, sites=sites,
  File "/Users/jhariharan/Documents/dataretrieval-1/dataretrieval/nwis.py", line 504, in _iv
    df = _read_json(response.json())
  File "/Users/jhariharan/Documents/dataretrieval-1/dataretrieval/nwis.py", line 803, in _read_json
    merged_df['datetime'] = pd.to_datetime(merged_df['datetime'], utc=True)
  File "/Users/jhariharan/mambaforge/envs/dataretrieval/lib/python3.10/site-packages/pandas/core/frame.py", line 3805, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/Users/jhariharan/mambaforge/envs/dataretrieval/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3802, in get_loc
    raise KeyError(key) from err
KeyError: 'datetime'
```

This PR closes #26 by adding a check and only modifying the datetime column if a 'datetime' column is available in the first place. In doing so, behavior is restored to what it was before: if a query does not return any data, the `dataretrieval` function returns an empty data frame.

A test has been added using the example from #26. The time object errors described in the issue match what was resolved by #62, so I think those aspects of the original issue have already been fixed.