### PR TITLE
Improve documentation

### DIFF
--- a/dataretrieval/codes/states.py
+++ b/dataretrieval/codes/states.py
@@ -1,4 +1,5 @@
-state_codes =[
+"""List of 2-digit state codes with commented full names."""
+state_codes = [
     'al', # Alabama
     'ak', # Alaska
     'az', # Arizona

--- a/dataretrieval/nadp.py
+++ b/dataretrieval/nadp.py
@@ -4,21 +4,24 @@ the National Trends Network (NTN), the Mercury Deposition Network (MDN).
 
 National Trends Network
 -----------------------
-The  NTN provides longterm records of precipitation chemistry across the United States.
-See https://nadp.slh.wisc.edu/ntn for more info.
+The  NTN provides long-term records of precipitation chemistry across the
+United States. See https://nadp.slh.wisc.edu/ntn for more info.
 
 Mercury Deposition Network
 --------------------------
-The MDN provides longterm records of total mercury (Hg) concentration and deposition in precipitation in the United States and Canada.
-For more information visit https://nadp.slh.wisc.edu/networks/mercury-deposition-network/
+The MDN provides long-term records of total mercury (Hg) concentration and
+deposition in precipitation in the United States and Canada. For more
+information visit https://nadp.slh.wisc.edu/networks/mercury-deposition-network/
 
 Notes
 -----
-Gridded data on NADP is served as zipped tif files. Functions in this module will either download and extract the data,
-when a path is specified, or open the data as a GDAL memory-mapped file when no path is specified.
+Gridded data on NADP is served as zipped tif files. Functions in this module
+will either download and extract the data, when a path is specified, or open
+the data as a GDAL memory-mapped file when no path is specified.
 
 .. todo::
     - include AIRMoN, AMNet, and AMoN
+    - flexible handling of strings for parameters and measurement types
     - add errorchecking
     - add tests
 
@@ -38,18 +41,20 @@ from os.path import basename
 from uuid import uuid4
 
 NADP_URL = 'https://nadp.slh.wisc.edu'
-NADP_MAP_EXT = 'maplib/grids'
+NADP_MAP_EXT = 'filelib/maps'
 
-NTN_CONC_PARAMS = ['pH','So4','NO3','NH4','Ca','Mg','K','Na','Cl','Br']
-NTN_DEP_PARAMS  = ['H','So4','NO3','NH4','Ca','Mg','K','Na','Cl','Br','N','SPlusN']
+NTN_CONC_PARAMS = ['pH', 'So4', 'NO3', 'NH4', 'Ca',
+                   'Mg', 'K', 'Na', 'Cl', 'Br']
+NTN_DEP_PARAMS  = ['H', 'So4', 'NO3', 'NH4', 'Ca', 'Mg',
+                   'K', 'Na', 'Cl', 'Br', 'N', 'SPlusN']
 
-NTN_MEAS_TYPE = ['conc','dep','precip']  #concentration or deposition
+NTN_MEAS_TYPE = ['conc', 'dep', 'precip']  # concentration or deposition
 
 
 class GDALMemFile():
     """Creates a GDAL memory-mapped file
 
-    Modeled after `rasterio` function of same name
+    Modeled after ``rasterio`` function of same name
 
     .. code::
 
@@ -76,7 +81,7 @@ class GDALMemFile():
         see https://gist.github.com/jleinonen/5781308
 
         """
-        mmap_name = '/vsimem/' + uuid4().hex #vsimem is special GDAL string
+        mmap_name = '/vsimem/' + uuid4().hex  # vsimem is special GDAL string
         gdal.FileFromMemBuffer(mmap_name, self.buf)
 
         return gdal.Open(mmap_name)
@@ -86,31 +91,62 @@ class NADP_ZipFile(zipfile.ZipFile):
     """Extend zipfile.ZipFile for working on data from NADP
     """
     def tif_name(self):
+        """Get the name of the tif file in the zip file."""
         filenames = self.namelist()
         r = re.compile(".*tif$")
         tif_list = list(filter(r.match, filenames))
         return tif_list[0]
 
     def tif(self):
-        return self.read( self.tif_name() )
+        """Read the tif file in the zip file."""
+        return self.read(self.tif_name())
 
 
 def get_annual_MDN_map(measurement_type, year, path=None):
-    """Download a MDN map from NDAP
+    """Download a MDN map from NDAP.
+
+    This function looks for a zip file containing gridded information at:
+    https://nadp.slh.wisc.edu/maps-data/mdn-gradient-maps/.
+    The function will download the zip file and extract it, exposing the tif
+    file if a path is provided. If not, then a
+    :obj:`dataretrieval.nadp.GDALMemFile` object is returned.
 
     Parameters
     ----------
-    measurement_type : string
-        The type of measurement (concentration or deposition)
+    measurement_type: string
+        The type of measurement (concentration or deposition) as a string,
+        either 'conc' or 'dep' respectively.
 
-    year : string
+    year: string
+        Year as a string 'YYYY'
 
-    path : string
-        download directory
+    path: string
+        Download directory
+
+    Returns
+    -------
+    path: string
+        Path that zip file was extracted into if path was specified.
+
+    GDALMemFile: :obj:`dataretrieval.nadp.GDALMemFile`
+        GDALMemFile containing in-memory GDAL object.
+
+    Examples
+    --------
+    .. code::
+
+        >>> # get map of mercury concentration in 2010 and extract it to a path
+        >>> data_path = dataretrieval.nadp.get_annual_MDN_map(
+        ...     measurement_type='conc', year='2010', path='somepath')
+
+        >>> # get map of mercury deposition in 2008 as a GDALMemFile object
+        >>> gmem = dataretrieval.nadp.get_annual_MDN_map(
+        ...     measurement_type='dep', year='2008')
+
     """
-    url = '{}/{}/mdn/'.format(NADP_URL, NADP_MAP_EXT)
+    url = '{}/{}/MDN/grids/'.format(NADP_URL, NADP_MAP_EXT)
 
-    filename = 'Hg_{}_{}.zip'.format(measurement_type,year)
+    filename = 'Hg_{}_{}.zip'.format(measurement_type, year)
 
     z = get_zip(url, filename)
 
@@ -125,32 +161,52 @@ def get_annual_MDN_map(measurement_type, year, path=None):
 def get_annual_NTN_map(measurement_type, measurement=None, year=None, path=None):
     """Download a NTN map from NDAP.
 
+    This function looks for a zip file containing gridded information at:
+    https://nadp.slh.wisc.edu/maps-data/ntn-gradient-maps/.
+    The function will download the zip file and extract it, exposing the tif
+    file if a path is provided. If not, then a
+    :obj:`dataretrieval.nadp.GDALMemFile` object is returned.
+
+    .. note::
+
+        Measurement type abbreviations for concentration and deposition are
+        all lower-case, but for precipitation data, the first letter must be
+        capitalized!
+
     Parameters
     ----------
     measurement : string
         The measured constituent to return.
     measurement_type : string
-        The type of measurement (concentration, deposition, or precip)
+        The type of measurement, 'conc', 'dep', or 'Precip', which represent
+        concentration, deposition, or precipitation respectively.
     year : string
-
+        Year as a string 'YYYY'
     path : string
-        download directory
+        Download directory
 
     Returns
     -------
-    GDALMemFile containing in-memory GDAL object.
-    or
-    Path that data was extracted into if path was specified.
+    path: string
+        Path that zip file was extracted into if path was specified.
+
+    GDALMemFile: :obj:`dataretrieval.nadp.GDALMemFile`
+        GDALMemFile containing in-memory GDAL object.
 
     Examples
     --------
     .. code::
 
-        >>> dataretrieval.nadp.get_annual_NTN_map(
+        >>> # get a map of nitrate concentration in 1996
+        >>> gmem = dataretrieval.nadp.get_annual_NTN_map(
         ...     measurement='NO3', measurement_type='conc', year='1996')
 
+        >>> # get a map of precipitation in 2015 and extract it to a path
+        >>> data_path = dataretrieval.nadp.get_annual_NTN_map(
+        ...     measurement_type='Precip', year='2015', path='somepath')
+
     """
-    url = '{}/{}/{}/'.format(NADP_URL, NADP_MAP_EXT, year)
+    url = '{}/{}/NTN/grids/{}/'.format(NADP_URL, NADP_MAP_EXT, year)
 
     filename = '{}_{}.zip'.format(measurement_type, year)
 
@@ -170,10 +226,17 @@ def get_annual_NTN_map(measurement_type, measurement=None, year=None, path=None)
 def get_zip(url, filename):
     """Gets a ZipFile at url and returns it
 
+    Parameters
+    ----------
+    url : string
+        URL to zip file
+
+    filename : string
+        Name of zip file
+
     Returns
     -------
     ZipFile
-
 
     .. todo::
 

--- a/dataretrieval/nadp.py
+++ b/dataretrieval/nadp.py
@@ -20,6 +20,7 @@ will either download and extract the data, when a path is specified, or open
 the data as a GDAL memory-mapped file when no path is specified.
 
 .. todo::
+
     - include AIRMoN, AMNet, and AMoN
     - flexible handling of strings for parameters and measurement types
     - add errorchecking

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -147,7 +147,7 @@ def get_qwdata(sites=None, start=None, end=None,
     .. doctest::
 
         >>> # get water sample information for site 11447650
-        >>> df, md = get_qwdata(
+        >>> df, md = dataretrieval.nwis.get_qwdata(
         ...     sites='11447650', start='2010-01-01', end='2010-02-01')
 
     """
@@ -241,11 +241,11 @@ def get_discharge_measurements(sites=None, start=None, end=None, **kwargs):
     .. doctest::
 
         >>> # Get discharge measurements for site 05114000
-        >>> df, md = get_discharge_measurements(
+        >>> df, md = dataretrieval.nwis.get_discharge_measurements(
         ...     sites='05114000', start='2000-01-01', end='2000-01-30')
 
         >>> # Get discharge measurements for sites in Alaska
-        >>> df, md = get_discharge_measurements(
+        >>> df, md = dataretrieval.nwis.get_discharge_measurements(
         ...     start='2012-01-09', end='2012-01-10', stateCd='AK')
 
     """
@@ -294,11 +294,11 @@ def get_discharge_peaks(sites=None, start=None, end=None,
     .. doctest::
 
         >>> # Get discharge peaks for site 01491000
-        >>> df, md = get_discharge_peaks(
+        >>> df, md = dataretrieval.nwis.get_discharge_peaks(
         ...     sites='01491000', start='1980-01-01', end='1990-01-01')
 
         >>> # Get discharge peaks for sites in Hawaii
-        >>> df, md = get_discharge_peaks(
+        >>> df, md = dataretrieval.nwis.get_discharge_peaks(
         ...     start='1980-01-01', end='1980-01-02', stateCd='HI')
 
     """
@@ -350,7 +350,7 @@ def get_gwlevels(sites=None, start='1851-01-01', end=None,
     .. doctest::
 
         >>> # Get groundwater levels for site 434400121275801
-        >>> df, md = get_gwlevels(sites='434400121275801')
+        >>> df, md = dataretrieval.nwis.get_gwlevels(sites='434400121275801')
 
     """
     start = kwargs.pop('startDT', start)

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -58,6 +58,8 @@ def format_response(df, service=None, **kwargs):
 
 
 def preformat_peaks_response(df):
+    """Datetime formatting for the 'peaks' service response.
+    """
     df['datetime'] = pd.to_datetime(df.pop('peak_dt'), errors='coerce')
     df.dropna(subset=['datetime'], inplace=True)
     return df
@@ -93,8 +95,15 @@ def get_qwdata(sites=None, start=None, end=None,
     **kwargs: optional
         If supplied, will be used as query parameters
 
-    Returns:
-        ``pandas.DataFrame`` containing times series data from the NWIS json and Metadata as tuple
+    Returns
+    -------
+    df: :obj:`pandas.DataFrame`
+        Times series data from the NWIS JSON
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
     """
     if wide_format:
         kwargs['qw_sample_wide'] = 'qw_sample_wide'
@@ -170,8 +179,15 @@ def get_discharge_measurements(sites=None, start=None, end=None, **kwargs):
     **kwargs: optional
         If supplied, will be used as query parameters
 
-    Returns:
-        ``pandas.DataFrame`` containing times series data from the NWIS json and Metadata as tuple
+    Returns
+    -------
+    df: :obj:`pandas.DataFrame`
+        Times series data from the NWIS JSON
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
     """
     start = kwargs.pop('begin_date', start)
     end = kwargs.pop('end_date', end)
@@ -202,8 +218,15 @@ def get_discharge_peaks(sites=None, start=None, end=None,
     **kwargs: optional
         If supplied, will be used as query parameters
 
-    Returns:
-        ``pandas.DataFrame`` containing times series data from the NWIS json and Metadata as tuple
+    Returns
+    -------
+    df: :obj:`pandas.DataFrame`
+        Times series data from the NWIS JSON
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
     """
     start = kwargs.pop('begin_date', start)
     end = kwargs.pop('end_date', end)
@@ -239,8 +262,15 @@ def get_gwlevels(sites=None, start='1851-01-01', end=None,
     **kwargs: optional
         If supplied, will be used as query parameters
 
-    Returns:
-        ``pandas.DataFrame`` containing times series data from the NWIS json and Metadata as tuple
+    Returns
+    -------
+    df: :obj:`pandas.DataFrame`
+        Times series data from the NWIS JSON
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
@@ -280,6 +310,17 @@ def get_stats(sites, **kwargs):
     .. todo::
 
         fix date parsing
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> df, md = dataretrieval.nwis.get_stats(
+        ...     sites='01646500', statReportType='annual' statYearType='water')
+
+        >>> df, md = dataretrieval.nwis.get_stats(
+        ...     sites='01646500', statReportType='monthly')
 
     """
     response = query_waterservices('stat', sites=sites, **kwargs)
@@ -329,7 +370,8 @@ def query_waterservices(service, **kwargs):
             end date
         modifiedSince: string
 
-    Returns:
+    Returns
+    -------
         request
 
     Usage: must specify one major filter: sites, stateCd, bBox,
@@ -364,8 +406,15 @@ def get_dv(sites=None, start=None, end=None, multi_index=True, **kwargs):
     **kwargs: optional
         If supplied, will be used as query parameters
 
-    Returns:
-        ``pandas.DataFrame`` containing times series data from the NWIS json and Metadata as tuple
+    Returns
+    -------
+    df: :obj:`pandas.DataFrame`
+        Times series data from the NWIS JSON
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
@@ -463,6 +512,9 @@ def get_info(**kwargs):
 
     For additional parameter options see
     https://waterservices.usgs.gov/rest/Site-Service.html#stateCd
+
+    Examples
+    --------
     """
     seriesCatalogOutput = kwargs.pop('seriesCatalogOutput', None)
     if seriesCatalogOutput in ['True', 'TRUE', 'true', True]:
@@ -480,7 +532,9 @@ def get_info(**kwargs):
 def get_iv(sites=None, start=None, end=None, multi_index=True, **kwargs):
     """Get instantaneous values data from NWIS and return it as a DataFrame.
 
-    Note: If no start or end date are provided, only the most recent record is returned.
+    .. note::
+
+        If no start or end date are provided, only the most recent record is returned.
 
     Parameters
     ----------
@@ -489,8 +543,15 @@ def get_iv(sites=None, start=None, end=None, multi_index=True, **kwargs):
     end: string
         If the waterdata parameter endDT is supplied, it will overwrite the end parameter
 
-    Returns:
-        ``pandas.DataFrame`` containing times series data from the NWIS json and Metadata as tuple
+    Returns
+    -------
+    df: :obj:`pandas.DataFrame`
+        Times series data from the NWIS JSON
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
@@ -511,13 +572,32 @@ def get_pmcodes(parameterCd='All', partial=True):
 
     Parameters
     ----------
-        parameterCd: string or list
-            Accepts parameter codes or names
+    parameterCd: string or list
+        Accepts parameter codes or names
 
-        partial: boolean
-            Default is True (partial querying). If False, the function will query only exact matches
-    Returns:
-        DataFrame containing the USGS parameter codes and Metadata as tuple
+    partial: boolean
+        Default is True (partial querying). If False, the function will query
+        only exact matches
+
+    Returns
+    -------
+    df: :obj:`pandas.DataFrame`
+        Times series data from the NWIS JSON
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> # Get information about the '00060' pcode
+        >>> df, md = dataretrieval.nwis.get_pmcodes(
+        ...     parameterCd='00060', partial=False)
+
+        >>> # Get information about all 'Discharge' pcodes
+        >>> df, md = dataretrieval.nwis.get_pmcodes(
+        ...     parameterCd='Discharge', partial=True)
 
     """
     if parameterCd is None:
@@ -576,7 +656,24 @@ def get_water_use(years="ALL", state=None, counties="ALL", categories="ALL"):
 
     Returns
     -------
-        ``pandas.DataFrame`` containing requested data and Metadata as tuple
+    df: :obj:`pandas.DataFrame`
+        Data from NWIS
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> # Get total population for RI from the NWIS water use service
+        >>> df, md = dataretrieval.nwis.get_water_use(
+        ...     years='2000', state='RI', categories='TP')
+
+        >>> # Get the national total water use for livestock in Bgal/day
+        >>> df, md = dataretrieval.nwis.get_water_use(
+        ...     years='2010', categories='L')
+
     """
     payload = {'rdb_compression' : 'value',
                'format' : 'rdb',
@@ -593,7 +690,8 @@ def get_water_use(years="ALL", state=None, counties="ALL", categories="ALL"):
 
 def get_ratings(site=None, file_type="base", **kwargs):
     """
-    Rating table for an active USGS streamgage retrieval
+    Rating table for an active USGS streamgage retrieval.
+
     Reads current rating table for an active USGS streamgage from NWISweb.
     Data is retrieved from https://waterdata.usgs.gov/nwis.
 
@@ -611,8 +709,20 @@ def get_ratings(site=None, file_type="base", **kwargs):
     **kwargs: optional
         If supplied, will be used as query parameters
 
-    Return:
-        ``pandas.DataFrame`` containing requested data and Metadata as tuple
+    Return
+    ------
+    df: :obj:`pandas.DataFrame`
+        Formatted requested data
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> df, md = dataretrieval.nwis.get_ratings(site='01594440')
+
     """
     site = kwargs.pop('site_no', site)
     return _ratings(site=site, file_type=file_type, **kwargs)
@@ -637,7 +747,20 @@ def what_sites(**kwargs):
 
     Parameters
     ----------
-    same as get_info
+    same as :obj:`dataretrieval.nwis.get_info`
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> # get information about a single site
+        >>> df, md = dataretrieval.nwis.what_sites(sites='05114000)
+
+        >>> # get information about sites with phosphorus in Ohio
+        >>> df, md = dataretrieval.nwis.what_sites(
+        ...     stateCd='OH', parameterCd='00665')
+
     """
 
     response = query_waterservices(service='site', **kwargs)
@@ -653,7 +776,9 @@ def get_record(sites=None, start=None, end=None,
     """
     Get data from NWIS and return it as a ``pandas.DataFrame``.
 
-    Note: If no start or end date are provided, only the most recent record is returned.
+    .. note::
+
+        If no start or end date are provided, only the most recent record is returned.
 
     Parameters
     ----------
@@ -676,6 +801,8 @@ def get_record(sites=None, start=None, end=None,
     -------
         ``pandas.DataFrame`` containing requested data
 
+    Examples
+    --------
     """
     if service not in WATERSERVICES_SERVICES + WATERDATA_SERVICES:
         raise TypeError('Unrecognized service: {}'.format(service))
@@ -737,12 +864,18 @@ def _read_json(json):
     """
     Reads a NWIS Water Services formatted JSON into a ``pandas.DataFrame``.
 
-    Args:
-        json: dict
-            A JSON dictionary response to be parsed into a ``pandas.DataFrame``
+    Parameters
+    ----------
+    json: dict
+        A JSON dictionary response to be parsed into a ``pandas.DataFrame``
 
-    Returns:
-        ``pandas.DataFrame`` containing times series data from the NWIS json and Metadata as tuple
+    Returns
+    -------
+    df: :obj:`pandas.DataFrame`
+        Times series data from the NWIS JSON
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
     """
     merged_df = pd.DataFrame()
 
@@ -810,9 +943,16 @@ def _read_rdb(rdb):
     """
     Convert NWIS rdb table into a ``pandas.dataframe``.
 
-    Args:
-        rdb: string
-            A string representation of an rdb table
+    Parameters
+    ----------
+    rdb: string
+        A string representation of an rdb table
+
+    Returns
+    -------
+    df: ``pandas.dataframe``
+        A formatted pandas data frame
+
     """
     count = 0
 
@@ -838,11 +978,18 @@ def _read_rdb(rdb):
 def _set_metadata(response, **parameters):
     """Generates a standard set of metadata informed by the response.
 
-    Args:
-        response: Response
-             Response object from requests module
-        parameters: unpacked dictionary
-            unpacked dictionary of the parameters supplied in the request
+    Parameters
+    ----------
+    response: Response
+        Response object from requests module
+    parameters: unpacked dictionary
+        Unpacked dictionary of the parameters supplied in the request
+
+    Returns
+    -------
+    md: :obj:`dataretrieval.utils.Metadata`
+        A ``dataretrieval`` custom :obj:`dataretrieval.utils.Metadata` object.
+
     """
     md = set_md(response)
     # site_no is preferred over sites to set site_info if both are present,

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -17,7 +17,8 @@ import pandas as pd
 from io import StringIO
 import re
 
-from dataretrieval.utils import to_str, format_datetime, update_merge, set_metadata as set_md
+from dataretrieval.utils import to_str, format_datetime, update_merge
+from dataretrieval.utils import set_metadata as set_md
 from .utils import query
 
 WATERDATA_BASE_URL = 'https://nwis.waterdata.usgs.gov/'
@@ -76,20 +77,25 @@ def get_qwdata(sites=None, start=None, end=None,
         The NWIS qw data service is being deprecated. See this note from the
         R package for more information:
         https://doi-usgs.github.io/dataRetrieval/articles/qwdata_changes.html
-        If you have additional questions about the qw data service, email gs-w-IOW_PO_team@usgs.gov.
+        If you have additional questions about the qw data service,
+        email gs-w-IOW_PO_team@usgs.gov.
 
     Parameters
     ----------
     sites: array of strings
-        If the qwdata parameter site_no is supplied, it will overwrite the sites parameter
+        If the qwdata parameter site_no is supplied, it will overwrite the
+        sites parameter
     start: string
-        If the qwdata parameter begin_date is supplied, it will overwrite the start parameter
+        If the qwdata parameter begin_date is supplied, it will overwrite the
+        start parameter
     end: string
-        If the qwdata parameter end_date is supplied, it will overwrite the end parameter
+        If the qwdata parameter end_date is supplied, it will overwrite the
+        end parameter
     multi_index: boolean
         If False, a dataframe with a single-level index (datetime) is returned
     wide_format : boolean
-        If True, return data in wide format with multiple samples per row and one row per time
+        If True, return data in wide format with multiple samples per row and
+        one row per time
     datetime_index : boolean
         If True, create a datetime index
     **kwargs: optional
@@ -97,7 +103,7 @@ def get_qwdata(sites=None, start=None, end=None,
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Times series data from the NWIS JSON
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
@@ -140,7 +146,8 @@ def _qwdata(datetime_index=True, **kwargs):
 
         search_criteria = kwargs.get('list_of_search_criteria')
         if search_criteria:
-            kwargs['list_of_search_criteria'] = '{},{}'.format(search_criteria, 'multiple_parameter_cds')
+            kwargs['list_of_search_criteria'] = '{},{}'.format(
+                search_criteria, 'multiple_parameter_cds')
         else:
             kwargs['list_of_search_criteria'] = 'multiple_parameter_cds'
         #search_criteria = kwargs.get('list_of_search_criteria
@@ -171,17 +178,20 @@ def get_discharge_measurements(sites=None, start=None, end=None, **kwargs):
     Parameters
     ----------
     sites: array of strings
-        If the qwdata parameter site_no is supplied, it will overwrite the sites parameter
+        If the qwdata parameter site_no is supplied, it will overwrite the
+        sites parameter
     start: string
-        If the qwdata parameter begin_date is supplied, it will overwrite the start parameter
+        If the qwdata parameter begin_date is supplied, it will overwrite the
+        start parameter
     end: string
-        If the qwdata parameter end_date is supplied, it will overwrite the end parameter
+        If the qwdata parameter end_date is supplied, it will overwrite the
+        end parameter
     **kwargs: optional
         If supplied, will be used as query parameters
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Times series data from the NWIS JSON
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
@@ -192,7 +202,8 @@ def get_discharge_measurements(sites=None, start=None, end=None, **kwargs):
     start = kwargs.pop('begin_date', start)
     end = kwargs.pop('end_date', end)
     sites = kwargs.pop('site_no', sites)
-    return _discharge_measurements(site_no=sites, begin_date=start, end_date=end, **kwargs)
+    return _discharge_measurements(
+        site_no=sites, begin_date=start, end_date=end, **kwargs)
 
 
 def _discharge_measurements(**kwargs):
@@ -208,11 +219,14 @@ def get_discharge_peaks(sites=None, start=None, end=None,
     Parameters
     ----------
     sites: array of strings
-        If the waterdata parameter site_no is supplied, it will overwrite the sites parameter
+        If the waterdata parameter site_no is supplied, it will overwrite the
+        sites parameter
     start: string
-        If the waterdata parameter begin_date is supplied, it will overwrite the start parameter
+        If the waterdata parameter begin_date is supplied, it will overwrite
+        the start parameter
     end: string
-        If the waterdata parameter end_date is supplied, it will overwrite the end parameter
+        If the waterdata parameter end_date is supplied, it will overwrite
+        the end parameter
     multi_index: boolean
         If False, a dataframe with a single-level index (datetime) is returned
     **kwargs: optional
@@ -220,7 +234,7 @@ def get_discharge_peaks(sites=None, start=None, end=None,
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Times series data from the NWIS JSON
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
@@ -240,7 +254,8 @@ def _discharge_peaks(**kwargs):
 
     df = _read_rdb(response.text)
 
-    return format_response(df, service='peaks', **kwargs), _set_metadata(response, **kwargs)
+    return format_response(df, service='peaks', **kwargs), _set_metadata(
+        response, **kwargs)
 
 
 def get_gwlevels(sites=None, start='1851-01-01', end=None,
@@ -251,10 +266,11 @@ def get_gwlevels(sites=None, start='1851-01-01', end=None,
     Parameters
     ----------
     start: string
-        If the waterdata parameter begin_date is supplied, it will overwrite the start
-        parameter (defaults to '1851-01-01')
+        If the waterdata parameter begin_date is supplied, it will overwrite
+        the start parameter (defaults to '1851-01-01')
     end: string
-        If the waterdata parameter end_date is supplied, it will overwrite the end parameter
+        If the waterdata parameter end_date is supplied, it will overwrite the
+        end parameter
     multi_index: boolean
         If False, a dataframe with a single-level index (datetime) is returned
     datetime_index : boolean
@@ -264,7 +280,7 @@ def get_gwlevels(sites=None, start='1851-01-01', end=None,
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Times series data from the NWIS JSON
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
@@ -294,18 +310,32 @@ def _gwlevels(datetime_index=True, **kwargs):
 
 def get_stats(sites, **kwargs):
     """
-    Queries waterservices statistics information
+    Queries water services statistics information.
 
-    Parameters (Additional parameters, if supplied, will be used as query parameters)
-    ---------------------------------------------------------------------------------
-    Must specify
-        sites (string or list): USGS site number
-        statReportType (string): daily (default), monthly, or annual
-        statTypeCd (string): all, mean, max, min, median
+    For more information about the water services statistics service, visit
+    https://waterservices.usgs.gov/rest/Statistics-Service.html
+
+    Parameters
+    ----------
+    sites: string or list
+        USGS site number (or list of site numbers)
+
+    Additional Parameters
+    ---------------------
+    statReportType: string
+        daily (default), monthly, or annual
+    statTypeCd: string
+        all, mean, max, min, median
+    **kwargs: optional
+        Additional parameters that, if supplied, will be used as
+        query parameters
 
     Returns
     -------
-        ``pandas.Dataframe``
+    df: ``pandas.DataFrame``
+        Statistics data from the statistics service
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
 
     .. todo::
 
@@ -313,12 +343,13 @@ def get_stats(sites, **kwargs):
 
     Examples
     --------
-
     .. doctest::
 
+        >>> # Get annual water statistics for a site
         >>> df, md = dataretrieval.nwis.get_stats(
-        ...     sites='01646500', statReportType='annual' statYearType='water')
+        ...     sites='01646500', statReportType='annual', statYearType='water')
 
+        >>> # Get monthly statistics for a site
         >>> df, md = dataretrieval.nwis.get_stats(
         ...     sites='01646500', statReportType='monthly')
 
@@ -353,28 +384,39 @@ def query_waterdata(service, **kwargs):
 
 def query_waterservices(service, **kwargs):
     """
-    Querys waterservices.usgs.gov
+    Queries waterservices.usgs.gov
 
-    For more documentation see
+    For more documentation see https://waterservices.usgs.gov/rest/
 
-    Parameters (Additional parameters, if supplied, will be used as query parameters)
-    ---------------------------------------------------------------------------------
-        service: string
-            'site','stats',etc
-        bBox: huc string
-            7-digit Hydrologic Unit Code
+    .. note::
 
-        startDT: string
-            start date (2017-12-31)
-        endDT: string
-            end date
-        modifiedSince: string
+        User must specify one major filter: sites, stateCd, or bBox
+
+    Parameters
+    ----------
+    service: string
+        String specifying the service to query: 'site', 'stats', etc.
+    bBox: string
+        7-digit Hydrologic Unit Code (HUC)
+    startDT: string
+        Start date (e.g., '2017-12-31')
+    endDT: string
+        End date (e.g., '2018-01-01')
+    modifiedSince: string
+        Used to return only sites where attributes or period of record data
+        have changed during the request period. String expected to be formatted
+        in ISO-8601 duration format (e.g., 'P1D' for one day,
+        'P1Y' for one year)
+
+    Other Parameters
+    ----------------
+    **kwargs: optional
+        If supplied, will be used as query parameters
 
     Returns
     -------
-        request
-
-    Usage: must specify one major filter: sites, stateCd, bBox,
+    request: ``requests.models.Response``
+        The response object from the API request to the web service
 
     """
     if not any(key in kwargs for key in ['sites', 'stateCd', 'bBox', 'huc', 'countyCd']):
@@ -395,20 +437,25 @@ def get_dv(sites=None, start=None, end=None, multi_index=True, **kwargs):
     """
     Get daily values data from NWIS and return it as a ``pandas.DataFrame``.
 
-    Note: If no start or end date are provided, only the most recent record is returned.
+    .. note:
+
+        If no start or end date are provided, only the most recent record
+        is returned.
 
     Parameters
     ----------
     start: string
-        If the waterdata parameter startDT is supplied, it will overwrite the start parameter
+        If the waterdata parameter startDT is supplied, it will overwrite the
+        start parameter
     end: string
-        If the waterdata parameter endDT is supplied, it will overwrite the end parameter
+        If the waterdata parameter endDT is supplied, it will overwrite the
+        end parameter
     **kwargs: optional
         If supplied, will be used as query parameters
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Times series data from the NWIS JSON
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
@@ -513,8 +560,24 @@ def get_info(**kwargs):
     For additional parameter options see
     https://waterservices.usgs.gov/rest/Site-Service.html#stateCd
 
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Site data from the NWIS web service
+    md: :obj:`dataretrieval.utils.Metadata`
+        A custom metadata object
+
     Examples
     --------
+    .. doctest::
+
+        >>> # Get site information for a single site
+        >>> df, md = dataretrieval.nwis.get_info(sites='05114000')
+
+        >>> # Get site information for multiple sites
+        >>> df, md = dataretrieval.nwis.get_info(
+        ...     sites=['05114000', '09423350'])
+
     """
     seriesCatalogOutput = kwargs.pop('seriesCatalogOutput', None)
     if seriesCatalogOutput in ['True', 'TRUE', 'true', True]:
@@ -534,18 +597,21 @@ def get_iv(sites=None, start=None, end=None, multi_index=True, **kwargs):
 
     .. note::
 
-        If no start or end date are provided, only the most recent record is returned.
+        If no start or end date are provided, only the most recent record
+        is returned.
 
     Parameters
     ----------
     start: string
-        If the waterdata parameter startDT is supplied, it will overwrite the start parameter
+        If the waterdata parameter startDT is supplied, it will overwrite the
+        start parameter
     end: string
-        If the waterdata parameter endDT is supplied, it will overwrite the end parameter
+        If the waterdata parameter endDT is supplied, it will overwrite the
+        end parameter
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Times series data from the NWIS JSON
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
@@ -581,14 +647,13 @@ def get_pmcodes(parameterCd='All', partial=True):
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
-        Times series data from the NWIS JSON
+    df: ``pandas.DataFrame``
+        Data retrieved from the NWIS web service.
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
 
     Examples
     --------
-
     .. doctest::
 
         >>> # Get information about the '00060' pcode
@@ -603,10 +668,10 @@ def get_pmcodes(parameterCd='All', partial=True):
     if parameterCd is None:
         raise TypeError('The query must include a parameter name or code')
 
-    payload = {'fmt':'rdb'}
+    payload = {'fmt': 'rdb'}
     url = PARAMCODES_URL
 
-    if isinstance(parameterCd, str): # when a single code or name is given
+    if isinstance(parameterCd, str):  # when a single code or name is given
         if parameterCd.lower() == "all":
             payload.update({'group_cd': '%'})
             url = ALLPARAMCODES_URL
@@ -625,9 +690,9 @@ def get_pmcodes(parameterCd='All', partial=True):
         if isinstance(param, str):
             if partial:
                 param ='%{0}%'.format(param)
-            payload.update({'parm_nm_cd':param})
+            payload.update({'parm_nm_cd': param})
             response = query(url, payload)
-            if len(response.text.splitlines()) < 10: # empty query
+            if len(response.text.splitlines()) < 10:  # empty query
                 raise TypeError('One of the parameter codes or names entered does not return any information,'\
                                 ' please try a different value')
             l.append(_read_rdb(response.text))
@@ -642,28 +707,27 @@ def get_water_use(years="ALL", state=None, counties="ALL", categories="ALL"):
 
     Parameters
     ----------
-    years: Listlike
-        List or comma delimited string of years.  Must be years ending in 0 or 5, or "ALL",
-        which retrieves all available years
+    years: list-like
+        List or comma delimited string of years.  Must be years ending in 0 or
+        5, or "ALL", which retrieves all available years
     state: string
         full name, abbreviation or id
     county: string
         County IDs from county lookup or "ALL"
-    categories: Listlike
+    categories: list-like
         List or comma delimited string of Two-letter category abbreviations
     **kwargs: optional
         If supplied, will be used as query parameters
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Data from NWIS
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
 
     Examples
     --------
-
     .. doctest::
 
         >>> # Get total population for RI from the NWIS water use service
@@ -675,15 +739,15 @@ def get_water_use(years="ALL", state=None, counties="ALL", categories="ALL"):
         ...     years='2010', categories='L')
 
     """
-    payload = {'rdb_compression' : 'value',
-               'format' : 'rdb',
-               'wu_year' : years,
-               'wu_category' : categories,
-               'wu_county' : counties}
+    payload = {'rdb_compression': 'value',
+               'format': 'rdb',
+               'wu_year': years,
+               'wu_category': categories,
+               'wu_county': counties}
     url = WATERDATA_URL + 'water_use'
     if state is not None:
         url = WATERDATA_BASE_URL + state + "/nwis/water_use"
-        payload.update({"wu_area" : "county"})
+        payload.update({"wu_area": "county"})
     response = query(url, payload)
     return _read_rdb(response.text), _set_metadata(response)
 
@@ -699,28 +763,29 @@ def get_ratings(site=None, file_type="base", **kwargs):
     ----------
     site: string
         USGS site number.  This is usually an 8 digit number as a string.
-        If the nwis parameter site_no is supplied, it will overwrite the site parameter
+        If the nwis parameter site_no is supplied, it will overwrite the site
+        parameter
     base: string
         can be "base", "corr", or "exsa"
     county: string
         County IDs from county lookup or "ALL"
-    categories: Listlike
+    categories: list-like
         List or comma delimited string of Two-letter category abbreviations
     **kwargs: optional
         If supplied, will be used as query parameters
 
     Return
     ------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Formatted requested data
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
 
     Examples
     --------
-
     .. doctest::
 
+        >>> # Get the rating table for USGS streamgage 01594440
         >>> df, md = dataretrieval.nwis.get_ratings(site='01594440')
 
     """
@@ -747,15 +812,15 @@ def what_sites(**kwargs):
 
     Parameters
     ----------
-    same as :obj:`dataretrieval.nwis.get_info`
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.nwis.get_info`
 
     Examples
     --------
-
     .. doctest::
 
         >>> # get information about a single site
-        >>> df, md = dataretrieval.nwis.what_sites(sites='05114000)
+        >>> df, md = dataretrieval.nwis.what_sites(sites='05114000')
 
         >>> # get information about sites with phosphorus in Ohio
         >>> df, md = dataretrieval.nwis.what_sites(
@@ -778,11 +843,12 @@ def get_record(sites=None, start=None, end=None,
 
     .. note::
 
-        If no start or end date are provided, only the most recent record is returned.
+        If no start or end date are provided, only the most recent record is
+        returned.
 
     Parameters
     ----------
-    sites: listlike
+    sites: list-like
         List or comma delimited string of site.
     start: string
         Starting date of record (YYYY-MM-DD)
@@ -871,7 +937,7 @@ def _read_json(json):
 
     Returns
     -------
-    df: :obj:`pandas.DataFrame`
+    df: ``pandas.DataFrame``
         Times series data from the NWIS JSON
     md: :obj:`dataretrieval.utils.Metadata`
         A custom metadata object
@@ -966,7 +1032,8 @@ def _read_rdb(rdb):
 
     fields = re.split("[\t]", rdb.splitlines()[count])
     fields = [field.replace(",", "") for field in fields]
-    dtypes = {'site_no': str, 'dec_long_va': float, 'dec_lat_va': float, 'parm_cd': str, 'parameter_cd': str}
+    dtypes = {'site_no': str, 'dec_long_va': float,
+              'dec_lat_va': float, 'parm_cd': str, 'parameter_cd': str}
 
     df = pd.read_csv(StringIO(rdb), delimiter='\t', skiprows=count + 2,
                      names=fields, na_values='NaN', dtype=dtypes)

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -929,6 +929,11 @@ def get_record(sites=None, start=None, end=None,
         - 'qwdata' : discrete samples
         - 'site' : site description
         - 'measurements' : discharge measurements
+        - 'peaks': discharge peaks
+        - 'gwlevels': groundwater levels
+        - 'pmcodes': get parameter codes
+        - 'water_use': get water use data
+        - 'ratings': get rating table
     **kwargs: optional
         If supplied, will be used as query parameters
 
@@ -938,6 +943,46 @@ def get_record(sites=None, start=None, end=None,
 
     Examples
     --------
+    .. doctest::
+
+        >>> # Get latest instantaneous data from site 01585200
+        >>> df = dataretrieval.nwis.get_record(sites='01585200', service='iv')
+
+        >>> # Get latest daily mean data from site 01585200
+        >>> df = dataretrieval.nwis.get_record(sites='01585200', service='dv')
+
+        >>> # Get all discrete sample data from site 01585200
+        >>> df = dataretrieval.nwis.get_record(
+        ...     sites='01585200', service='qwdata')
+
+        >>> # Get site description for site 01585200
+        >>> df = dataretrieval.nwis.get_record(
+        ...     sites='01585200', service='site')
+
+        >>> # Get discharge measurements for site 01585200
+        >>> df = dataretrieval.nwis.get_record(
+        ...     sites='01585200', service='measurements')
+
+        >>> # Get discharge peaks for site 01585200
+        >>> df = dataretrieval.nwis.get_record(
+        ...     sites='01585200', service='peaks')
+
+        >>> # Get latest groundwater level for site 434400121275801
+        >>> df = dataretrieval.nwis.get_record(
+        ...     sites='434400121275801', service='gwlevels')
+
+        >>> # Get information about the discharge parameter code
+        >>> df = dataretrieval.nwis.get_record(
+        ...     service='pmcodes', parameterCd='00060')
+
+        >>> # Get water use data for livestock nationally in 2010
+        >>> df = dataretrieval.nwis.get_record(
+        ...     service='water_use', years='2010', categories='L')
+
+        >>> # Get rating table for USGS streamgage 01585200
+        >>> df = dataretrieval.nwis.get_record(
+        ...     sites='01585200', service='ratings')
+
     """
     if service not in WATERSERVICES_SERVICES + WATERDATA_SERVICES:
         raise TypeError('Unrecognized service: {}'.format(service))

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -33,6 +33,27 @@ WATERDATA_SERVICES = ['qwdata', 'measurements', 'peaks', 'pmcodes', 'water_use',
 
 def format_response(df, service=None, **kwargs):
     """Setup index for response from query.
+
+    This function formats the response from the NWIS web services, in
+    particular it sets the index of the data frame. This function tries to
+    convert the NWIS response into pandas datetime values localized to UTC,
+    and if possible, uses these timestamps to define the data frame index.
+
+    Parameters
+    ----------
+    df: ``pandas.DataFrame``
+        The data frame to format
+    service: string
+        The NWIS service that was queried, important because the 'peaks'
+        service returns a different format than the other services.
+    **kwargs: optional
+        Additional keyword arguments, e.g., 'multi_index'
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        The formatted data frame
+
     """
     mi = kwargs.pop('multi_index', True)
 
@@ -60,6 +81,19 @@ def format_response(df, service=None, **kwargs):
 
 def preformat_peaks_response(df):
     """Datetime formatting for the 'peaks' service response.
+
+    Function to format the datetime column of the 'peaks' service response.
+
+    Parameters
+    ----------
+    df: ``pandas.DataFrame``
+        The data frame to format
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        The formatted data frame
+
     """
     df['datetime'] = pd.to_datetime(df.pop('peak_dt'), errors='coerce')
     df.dropna(subset=['datetime'], inplace=True)
@@ -87,10 +121,10 @@ def get_qwdata(sites=None, start=None, end=None,
         sites parameter
     start: string
         If the qwdata parameter begin_date is supplied, it will overwrite the
-        start parameter
+        start parameter (YYYY-MM-DD)
     end: string
         If the qwdata parameter end_date is supplied, it will overwrite the
-        end parameter
+        end parameter (YYYY-MM-DD)
     multi_index: boolean
         If False, a dataframe with a single-level index (datetime) is returned
     wide_format : boolean
@@ -110,6 +144,12 @@ def get_qwdata(sites=None, start=None, end=None,
 
     Examples
     --------
+    .. doctest::
+
+        >>> # get water sample information for site 11447650
+        >>> df, md = get_qwdata(
+        ...     sites='11447650', start='2010-01-01', end='2010-02-01')
+
     """
     if wide_format:
         kwargs['qw_sample_wide'] = 'qw_sample_wide'
@@ -182,10 +222,10 @@ def get_discharge_measurements(sites=None, start=None, end=None, **kwargs):
         sites parameter
     start: string
         If the qwdata parameter begin_date is supplied, it will overwrite the
-        start parameter
+        start parameter (YYYY-MM-DD)
     end: string
         If the qwdata parameter end_date is supplied, it will overwrite the
-        end parameter
+        end parameter (YYYY-MM-DD)
     **kwargs: optional
         If supplied, will be used as query parameters
 
@@ -198,6 +238,16 @@ def get_discharge_measurements(sites=None, start=None, end=None, **kwargs):
 
     Examples
     --------
+    .. doctest::
+
+        >>> # Get discharge measurements for site 05114000
+        >>> df, md = get_discharge_measurements(
+        ...     sites='05114000', start='2000-01-01', end='2000-01-30')
+
+        >>> # Get discharge measurements for sites in Alaska
+        >>> df, md = get_discharge_measurements(
+        ...     start='2012-01-09', end='2012-01-10', stateCd='AK')
+
     """
     start = kwargs.pop('begin_date', start)
     end = kwargs.pop('end_date', end)
@@ -223,10 +273,10 @@ def get_discharge_peaks(sites=None, start=None, end=None,
         sites parameter
     start: string
         If the waterdata parameter begin_date is supplied, it will overwrite
-        the start parameter
+        the start parameter (YYYY-MM-DD)
     end: string
         If the waterdata parameter end_date is supplied, it will overwrite
-        the end parameter
+        the end parameter (YYYY-MM-DD)
     multi_index: boolean
         If False, a dataframe with a single-level index (datetime) is returned
     **kwargs: optional
@@ -241,6 +291,16 @@ def get_discharge_peaks(sites=None, start=None, end=None,
 
     Examples
     --------
+    .. doctest::
+
+        >>> # Get discharge peaks for site 01491000
+        >>> df, md = get_discharge_peaks(
+        ...     sites='01491000', start='1980-01-01', end='1990-01-01')
+
+        >>> # Get discharge peaks for sites in Hawaii
+        >>> df, md = get_discharge_peaks(
+        ...     start='1980-01-01', end='1980-01-02', stateCd='HI')
+
     """
     start = kwargs.pop('begin_date', start)
     end = kwargs.pop('end_date', end)
@@ -270,7 +330,7 @@ def get_gwlevels(sites=None, start='1851-01-01', end=None,
         the start parameter (defaults to '1851-01-01')
     end: string
         If the waterdata parameter end_date is supplied, it will overwrite the
-        end parameter
+        end parameter (YYYY-MM-DD)
     multi_index: boolean
         If False, a dataframe with a single-level index (datetime) is returned
     datetime_index : boolean
@@ -287,6 +347,11 @@ def get_gwlevels(sites=None, start='1851-01-01', end=None,
 
     Examples
     --------
+    .. doctest::
+
+        >>> # Get groundwater levels for site 434400121275801
+        >>> df, md = get_gwlevels(sites='434400121275801')
+
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
@@ -446,10 +511,10 @@ def get_dv(sites=None, start=None, end=None, multi_index=True, **kwargs):
     ----------
     start: string
         If the waterdata parameter startDT is supplied, it will overwrite the
-        start parameter
+        start parameter (YYYY-MM-DD)
     end: string
         If the waterdata parameter endDT is supplied, it will overwrite the
-        end parameter
+        end parameter (YYYY-MM-DD)
     **kwargs: optional
         If supplied, will be used as query parameters
 
@@ -462,6 +527,16 @@ def get_dv(sites=None, start=None, end=None, multi_index=True, **kwargs):
 
     Examples
     --------
+    .. doctest::
+
+        >>> # Get mean statistic daily values for site 04085427
+        >>> df, md = dataretrieval.nwis.get_dv(
+        ...     sites='04085427', start='2012-01-01', end='2012-06-30',
+        ...     statCd='00003')
+
+        >>> # Get the latest daily values for site 01646500
+        >>> df, md = dataretrieval.nwis.get_dv(sites='01646500')
+
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
@@ -481,84 +556,72 @@ def get_info(**kwargs):
     """
     Get site description information from NWIS.
 
-    Note: Must specify one major parameter.
+    **Note:** *Must specify one major parameter.*
+
+    For additional parameter options see
+    https://waterservices.usgs.gov/rest/Site-Service.html#stateCd
 
     Parameters
     ----------
-    sites : string or list
+    sites: string or list
         A list of site numbers. Sites may be prefixed with an optional agency
         code followed by a colon.
-
-    stateCd : string
+    stateCd: string
         U.S. postal service (2-digit) state code. Only 1 state can be specified
         per request.
-
-    huc : string or list
+    huc: string or list
         A list of hydrologic unit codes (HUC) or aggregated watersheds. Only 1
         major HUC can be specified per request, or up to 10 minor HUCs. A major
         HUC has two digits.
-
-    bBox : list
+    bBox: list
         A contiguous range of decimal latitude and longitude, starting with the
         west longitude, then the south latitude, then the east longitude, and
         then the north latitude with each value separated by a comma. The
         product of the range of latitude range and longitude cannot exceed 25
         degrees. Whole or decimal degrees must be specified, up to six digits
         of precision. Minutes and seconds are not allowed.
-
-    countyCd : string or list
+    countyCd: string or list
         A list of county numbers, in a 5 digit numeric format. The first two
         digits of a county's code are the FIPS State Code.
         (url: https://help.waterdata.usgs.gov/code/county_query?fmt=html)
-
     **kwargs: optional
         If supplied, will be used as query parameters
 
-    Minor Parameters
+    Other Parameters
     ----------------
-    startDt : string
+    startDt: string
         Selects sites based on whether data was collected at a point in time
         beginning after startDt (start date). Dates must be in ISO-8601
         Calendar Date format (for example: 1990-01-01).
-
-    endDt : string
-
-    period : string
+    endDt: string
+        The end date for the period of record. Dates must be in ISO-8601
+        Calendar Date format (for example: 1990-01-01).
+    period: string
         Selects sites based on whether or not they were active between now
         and a time in the past. For example, period=P10W will select sites
         active in the last ten weeks.
-
-    modifiedSince : string
+    modifiedSince: string
         Returns only sites where site attributes or period of record data have
         changed during the request period.
-
-    parameterCd : string or list
+    parameterCd: string or list
         Returns only site data for those sites containing the requested USGS
         parameter codes.
-
-    siteType : string or list
+    siteType: string or list
         Restricts sites to those having one or more major and/or minor site
         types, such as stream, spring or well. For a list of all valid site
         types see https://help.waterdata.usgs.gov/site_tp_cd
         For example, siteType='ST' returns streams only.
-
-    Formatting Parameters
-    ---------------------
-    siteOutput : string ('basic' or 'expanded')
+    siteOutput: string ('basic' or 'expanded')
         Indicates the richness of metadata you want for site attributes. Note
         that for visually oriented formats like Google Map format, this
         argument has no meaning. Note: for performance reasons,
         siteOutput=expanded cannot be used if seriesCatalogOutput=true or with
         any values for outputDataTypeCd.
-
-    seriesCatalogOutput : boolean
+    seriesCatalogOutput: boolean
         A switch that provides detailed period of record information for
         certain output formats. The period of record indicates date ranges for
         a certain kind of information about a site, for example the start and
         end dates for a site's daily mean streamflow.
-
-    For additional parameter options see
-    https://waterservices.usgs.gov/rest/Site-Service.html#stateCd
 
     Returns
     -------
@@ -604,10 +667,10 @@ def get_iv(sites=None, start=None, end=None, multi_index=True, **kwargs):
     ----------
     start: string
         If the waterdata parameter startDT is supplied, it will overwrite the
-        start parameter
+        start parameter (YYYY-MM-DD)
     end: string
         If the waterdata parameter endDT is supplied, it will overwrite the
-        end parameter
+        end parameter (YYYY-MM-DD)
 
     Returns
     -------
@@ -618,6 +681,13 @@ def get_iv(sites=None, start=None, end=None, multi_index=True, **kwargs):
 
     Examples
     --------
+    .. doctest::
+
+        >>> # Get instantaneous discharge data for site 05114000
+        >>> df, md = dataretrieval.nwis.get_iv(
+        ...     sites='05114000', start='2013-11-03', end='2013-11-03',
+        ...     parameterCd='00060')
+
     """
     start = kwargs.pop('startDT', start)
     end = kwargs.pop('endDT', end)
@@ -640,7 +710,6 @@ def get_pmcodes(parameterCd='All', partial=True):
     ----------
     parameterCd: string or list
         Accepts parameter codes or names
-
     partial: boolean
         Default is True (partial querying). If False, the function will query
         only exact matches
@@ -853,7 +922,7 @@ def get_record(sites=None, start=None, end=None,
     start: string
         Starting date of record (YYYY-MM-DD)
     end: string
-        Ending date of record.
+        Ending date of record. (YYYY-MM-DD)
     service: string
         - 'iv' : instantaneous data
         - 'dv' : daily mean data

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -807,6 +807,11 @@ def get_water_use(years="ALL", state=None, counties="ALL", categories="ALL"):
         >>> df, md = dataretrieval.nwis.get_water_use(
         ...     years='2010', categories='L')
 
+        >>> # Get 2005 domestic water use for Apache County in Arizona
+        >>> df, md = dataretrieval.nwis.get_water_use(
+        ...     years='2005', state='Arizona',
+        ...     counties='001', categories='DO')
+
     """
     payload = {'rdb_compression': 'value',
                'format': 'rdb',

--- a/dataretrieval/streamstats.py
+++ b/dataretrieval/streamstats.py
@@ -8,13 +8,14 @@ This module is a wrapper for the streamstats API (`streamstats documentation`_).
 import json
 import requests
 
-def download_workspace(filepath, workspaceID, format=''):
-    """
+
+def download_workspace(workspaceID, format=''):
+    """Function to download streamstats workspace.
 
     Parameters
     ----------
     workspaceID: string
-        Service workspace received form watershed result
+        Service workspace received from watershed result
 
     format: string
         Download return format. Default will return ESRI geodatabase zipfile.
@@ -43,6 +44,19 @@ def download_workspace(filepath, workspaceID, format=''):
 
 
 def get_sample_watershed():
+    """Sample function to get a watershed object for a location in NY.
+
+    Makes the function call :obj:`dataretrieval.streamstats.get_watershed`
+    with the parameters 'NY', -74.524, 43.939, and returns the watershed
+    object.
+
+    Returns
+    -------
+    Watershed: :obj:`dataretrieval.streamstats.Watershed`
+        Custom object that contains the watershed information as extracted
+        from the streamstats JSON object.
+
+    """
     return get_watershed('NY', -74.524, 43.939)
 
 
@@ -51,33 +65,45 @@ def get_watershed(rcode, xlocation, ylocation, crs=4326,
                   includefeatures=True, simplify=True, format='geojson'):
     """ Get watershed object based on location
 
-    Streamstats documentation
-    -------------------------
+    **Streamstats documentation:**
     Returns a watershed object. The request configuration will determine the
-    overall request response. However all returns will return a watershed object
-    with at least the workspaceid. The workspace id is the id to the service
-    workspace where files are stored and can be used for further processing such
-    as for downloads and flow statistic computations.
+    overall request response. However all returns will return a watershed
+    object with at least the workspaceid. The workspace id is the id to the
+    service workspace where files are stored and can be used for further
+    processing such as for downloads and flow statistic computations.
+
+    See: https://streamstats.usgs.gov/streamstatsservices/#/ for more
+    information.
 
     Parameters
     ----------
-    rcode: StreamStats 2-3 character code that identifies the Study Area -- either a
-            State or a Regional Study.
-    xlocation: X location of the most downstream point of desired study area.
-    ylocation: Y location of the most downstream point of desired study area.
-    crs: ESPSG spatial reference code.
-    includeparameters:
-    includeflowtypes: Not yet implemented.
-    includefeatures: Comma seperated list of features to include in response.
-    simplify:
+    rcode: string
+        StreamStats 2-3 character code that identifies the Study Area --
+        either a State or a Regional Study.
+    xlocation: float
+        X location of the most downstream point of desired study area.
+    ylocation: float
+        Y location of the most downstream point of desired study area.
+    crs: integer, string, optional
+        ESPSG spatial reference code, default is 4326
+    includeparameters: bool, optional
+        Boolean flag to include parameters in response.
+    includeflowtypes: bool, string, optional
+        Not yet implemented. Would be a comma separated list of region flow
+        types to compute with the default being True
+    includefeatures: list, optional
+        Comma separated list of features to include in response.
+    simplify: bool, optional
+        Boolean flag controlling whether or not to simplify the returned
+        result.
 
     Returns
     -------
-    Json watershed object describing watershed
+    Watershed: :obj:`dataretrieval.streamstats.Watershed`
+        Custom object that contains the watershed information as extracted
+        from the streamstats JSON object.
 
-    see: https://streamstats.usgs.gov/streamstatsservices/#/
     """
-
     payload = {'rcode': rcode, 'xlocation': xlocation, 'ylocation': ylocation,
                'crs': crs, 'includeparameters': includeparameters,
                'includeflowtypes': includeflowtypes,
@@ -104,9 +130,10 @@ def get_watershed(rcode, xlocation, ylocation, crs=4326,
 
 
 class Watershed:
-
+    """Class to extract information from the streamstats JSON object."""
     @classmethod
     def from_streamstats_json(cls, streamstats_json):
+        """Method that creates a Watershed object from a streamstats JSON."""
         cls.watershed_point = streamstats_json['featurecollection'][0]['feature']
         cls.watershed_polygon = streamstats_json['featurecollection'][1]['feature']
         cls.parameters = streamstats_json['parameters']
@@ -114,4 +141,5 @@ class Watershed:
         return cls
 
     def __init__(self, rcode, xlocation, ylocation):
+        """Init method that calls the :obj:`from_streamstats_json` method."""
         self = get_watershed(rcode, xlocation, ylocation)

--- a/dataretrieval/streamstats.py
+++ b/dataretrieval/streamstats.py
@@ -22,12 +22,12 @@ def download_workspace(filepath, workspaceID, format=''):
 
     Returns
     -------
-        r: geodatabase or shapefiles
-            A zip file containing the workspace contents, in either a
-            geodatabase or shape files.
+    r: geodatabase or shapefiles
+        A zip file containing the workspace contents, in either a
+        geodatabase or shape files.
 
     """
-    payload = {'workspaceID':workspaceID, 'format':format}
+    payload = {'workspaceID': workspaceID, 'format': format}
     url = 'https://streamstats.usgs.gov/streamstatsservices/download'
 
     r = requests.get(url, params=payload)
@@ -41,8 +41,10 @@ def download_workspace(filepath, workspaceID, format=''):
 
     #return
 
+
 def get_sample_watershed():
-    return get_watershed('NY',-74.524, 43.939)
+    return get_watershed('NY', -74.524, 43.939)
+
 
 def get_watershed(rcode, xlocation, ylocation, crs=4326,
                   includeparameters=True, includeflowtypes=False,
@@ -59,29 +61,30 @@ def get_watershed(rcode, xlocation, ylocation, crs=4326,
 
     Parameters
     ----------
-        rcode: StreamStats 2-3 character code that identifies the Study Area -- either a
-               State or a Regional Study.
-        xlocation: X location of the most downstream point of desired study area.
-        ylocation: Y location of the most downstream point of desired study area.
-        crs: ESPSG spatial reference code.
-        includeparameters:
-        includeflowtypes: Not yet implemented.
-        includefeatures: Comma seperated list of features to include in response.
-        simplify:
+    rcode: StreamStats 2-3 character code that identifies the Study Area -- either a
+            State or a Regional Study.
+    xlocation: X location of the most downstream point of desired study area.
+    ylocation: Y location of the most downstream point of desired study area.
+    crs: ESPSG spatial reference code.
+    includeparameters:
+    includeflowtypes: Not yet implemented.
+    includefeatures: Comma seperated list of features to include in response.
+    simplify:
 
     Returns
     -------
-        Json watershed object describing watershed
+    Json watershed object describing watershed
 
     see: https://streamstats.usgs.gov/streamstatsservices/#/
     """
 
-    payload = {'rcode':rcode, 'xlocation':xlocation, 'ylocation':ylocation, 'crs':crs,
-               'includeparameters':includeparameters, 'includeflowtypes':includeflowtypes,
-               'includefeatures':includefeatures, 'simplify':simplify}
+    payload = {'rcode': rcode, 'xlocation': xlocation, 'ylocation': ylocation,
+               'crs': crs, 'includeparameters': includeparameters,
+               'includeflowtypes': includeflowtypes,
+               'includefeatures': includefeatures, 'simplify': simplify}
     url = 'https://streamstats.usgs.gov/streamstatsservices/watershed.geojson'
 
-    r   = requests.get(url, params=payload)
+    r = requests.get(url, params=payload)
 
     r.raise_for_status()
 
@@ -96,9 +99,9 @@ def get_watershed(rcode, xlocation, ylocation, crs=4326,
         # return a python object
         pass
 
-    #data = r.json() #raise error
     data = json.loads(r.text)
     return Watershed.from_streamstats_json(data)
+
 
 class Watershed:
 

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -11,9 +11,32 @@ from dataretrieval.codes import tz
 def to_str(listlike, delimiter=','):
     """Translates list-like objects into strings.
 
+    Parameters
+    ----------
+    listlike: list-like object
+        An object that is a list, or list-like
+        (e.g., :obj:`pandas.core.series.Series`)
+
+    delimiter: string, optional
+        The delimiter that is placed between entries in listlike when it is
+        turned into a string. Default value is a comma.
+
     Returns
     -------
-        List-like object as string
+    listlike: string
+        The listlike object as string separated by the delimiter
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> to_str([1, 'a', 2])
+            '1,a,2'
+
+        >>> to_str([0, 10, 42], delimiter='+')
+            '0+10+42'
+
     """
     if type(listlike) == list:
         return delimiter.join([str(x) for x in listlike])
@@ -119,6 +142,8 @@ def update_merge(left, right, na_only=False, on=None, **kwargs):
 
 
 class Metadata:
+    """Custom class for metadata.
+    """
     url = None
     query_time = None
     site_info = None
@@ -133,6 +158,8 @@ class Metadata:
 
 
 def set_metadata(response):
+    """Function to initialize and set metadata from an API response.
+    """
     md = Metadata()
     md.url = response.url
     md.query_time = response.elapsed
@@ -148,13 +175,16 @@ def query(url, payload, delimiter=','):
 
     Parameters
     ----------
-        url :
-        payload : query parameters passed to requests.get
-        delimiter : delimeter to use with lists
+        url: string
+            URL to query
+        payload: dict
+            query parameters passed to requests.get
+        delimiter: string
+            delimeter to use with lists
 
     Returns
     -------
-        string : query response
+        string: query response
     """
 
     for key, value in payload.items():
@@ -177,6 +207,8 @@ def query(url, payload, delimiter=','):
 
 
 class NoSitesError(Exception):
+    """Custom error class used when selection criteria returns no sites/data.
+    """
     def __init__(self, url):
         self.url = url
 

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -193,7 +193,19 @@ def query(url, payload, delimiter=','):
     if response.status_code == 400:
         raise ValueError("Bad Request, check that your parameters are correct. URL: {}".format(response.url))
     elif response.status_code == 414:
-        raise ValueError("Request URL too long. Modify your query to use fewer sites. API response reason: {}".format(response.reason))
+        _reason = response.reason
+        _example = """
+                    split_list = np.array_split(site_list, n)  # n is number of chunks to divide query into \n
+                    data_list = []  # list to store chunk results in \n
+                    # loop through chunks and make requests \n
+                    for site_list in split_list: \n
+                        data = nwis.get_record(sites=site_list, service='dv', start=start, end=end) \n
+                        data_list.append(data)  # append results to list"""
+        raise ValueError(
+            "Request URL too long. Modify your query to use fewer sites. " +
+            f"API response reason: {_reason}. Pseudo-code example of how to " +
+            f"split your query: \n {_example}"
+            )
 
     if response.text.startswith('No sites/data'):
         raise NoSitesError(response.url)

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -15,7 +15,7 @@ def to_str(listlike, delimiter=','):
     ----------
     listlike: list-like object
         An object that is a list, or list-like
-        (e.g., :obj:`pandas.core.series.Series`)
+        (e.g., ``pandas.core.series.Series``)
 
     delimiter: string, optional
         The delimiter that is placed between entries in listlike when it is
@@ -28,7 +28,6 @@ def to_str(listlike, delimiter=','):
 
     Examples
     --------
-
     .. doctest::
 
         >>> dataretrieval.utils.to_str([1, 'a', 2])
@@ -60,7 +59,7 @@ def format_datetime(df, date_field, time_field, tz_field):
     Parameters
     ----------
     df : ``pandas.DataFrame``
-        ``pandas.DataFrame`` containing date, time, and timezone fields.
+        A data frame containing date, time, and timezone fields.
 
     date_field : string
         Name of date column in df.
@@ -74,6 +73,7 @@ def format_datetime(df, date_field, time_field, tz_field):
     Returns
     -------
     df : ``pandas.DataFrame``
+        The data frame with a formatted 'datetime' column
     """
 
     # create a datetime index from the columns in qwdata response
@@ -102,16 +102,16 @@ def update_merge(left, right, na_only=False, on=None, **kwargs):
     Parameters
     ----------
     left: ``pandas.DataFrame``
-        original data
+        Original data
     right: ``pandas.DataFrame``
-        updated data
+        Updated data
     na_only: bool
-        if True, only update na values
+        If True, only update na values
 
     Returns
     -------
     df: ``pandas.DataFrame``
-        updated data
+        Updated data frame
 
 
     .. todo::

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -2,7 +2,6 @@
 Useful utilities for data munging.
 """
 import warnings
-import numpy as np
 import pandas as pd
 import requests
 from dataretrieval.codes import tz
@@ -16,7 +15,6 @@ def to_str(listlike, delimiter=','):
     listlike: list-like object
         An object that is a list, or list-like
         (e.g., ``pandas.core.series.Series``)
-
     delimiter: string, optional
         The delimiter that is placed between entries in listlike when it is
         turned into a string. Default value is a comma.
@@ -58,24 +56,21 @@ def format_datetime(df, date_field, time_field, tz_field):
 
     Parameters
     ----------
-    df : ``pandas.DataFrame``
+    df: ``pandas.DataFrame``
         A data frame containing date, time, and timezone fields.
-
-    date_field : string
+    date_field: string
         Name of date column in df.
-
-    time_field : string
+    time_field: string
         Name of time column in df.
-
-    tz_field : string
+    tz_field: string
         Name of time zone column in df.
 
     Returns
     -------
-    df : ``pandas.DataFrame``
+    df: ``pandas.DataFrame``
         The data frame with a formatted 'datetime' column
-    """
 
+    """
     # create a datetime index from the columns in qwdata response
     df[tz_field] = df[tz_field].map(tz)
 
@@ -112,7 +107,6 @@ def update_merge(left, right, na_only=False, on=None, **kwargs):
     -------
     df: ``pandas.DataFrame``
         Updated data frame
-
 
     .. todo::
 
@@ -175,16 +169,17 @@ def query(url, payload, delimiter=','):
 
     Parameters
     ----------
-        url: string
-            URL to query
-        payload: dict
-            query parameters passed to requests.get
-        delimiter: string
-            delimeter to use with lists
+    url: string
+        URL to query
+    payload: dict
+        query parameters passed to ``requests.get``
+    delimiter: string
+        delimiter to use with lists
 
     Returns
     -------
-        string: query response
+    string: query response
+        The response from the API query ``requests.get`` function call.
     """
 
     for key, value in payload.items():

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -31,11 +31,11 @@ def to_str(listlike, delimiter=','):
 
     .. doctest::
 
-        >>> to_str([1, 'a', 2])
-            '1,a,2'
+        >>> dataretrieval.utils.to_str([1, 'a', 2])
+        '1,a,2'
 
-        >>> to_str([0, 10, 42], delimiter='+')
-            '0+10+42'
+        >>> dataretrieval.utils.to_str([0, 10, 42], delimiter='+')
+        '0+10+42'
 
     """
     if type(listlike) == list:

--- a/dataretrieval/waterwatch.py
+++ b/dataretrieval/waterwatch.py
@@ -20,18 +20,18 @@ def get_flood_stage(sites: List[str] = None, fmt: str= "DF") -> Union[pd.DataFra
     ----------
     sites: List of strings
         Site numbers
-    fmt
-        Returned format: Default is "DF" for ``pandas.DataFrame``, else ``dict``
+    fmt: ``pandas.DataFrame`` or dict
+        Returned format: Default is "DF" for ``pandas.DataFrame``, else
+        a dictionary is returned.
 
     Returns
     -------
-        station_stages:``pandas.Dataframe`` or ``dict``
-            contains station numbers and their flood stages.
-            If no flood stage for a station, ``None`` is returned.
+    station_stages: ``pandas.Dataframe`` or dict
+        contains station numbers and their flood stages.
+        If no flood stage for a station, ``None`` is returned.
 
     Examples
     --------
-
     .. doctest::
 
         >> stations = ["07144100", "07144101"]

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -11,10 +11,12 @@ See https://waterqualitydata.us/webservices_documentation for API reference
 import pandas as pd
 from io import StringIO
 from .utils import query, set_metadata as set_md
+import warnings
 
 
 def get_results(**kwargs):
-    """
+    """Query the WQP for results.
+
     Parameters
     ----------
     siteid: string
@@ -29,11 +31,11 @@ def get_results(**kwargs):
         One or more eight-digit hydrologic units, delimited by semicolons.
     bBox: string
         Bounding box (Example: bBox=-92.8,44.2,-88.9,46.0)
-    lat: float
+    lat: string
         Latitude for radial search, expressed in decimal degrees, WGS84
-    long: float
+    long: string
         Longitude for radial search
-    within: float
+    within: string
         Distance for a radial search, expressed in decimal miles
     pCode: string
         One or more five-digit USGS parameter codes, separated by semicolons.
@@ -64,9 +66,18 @@ def get_results(**kwargs):
 
     Examples
     --------
+    .. code::
+
+        >>> # Get results within a radial distance of a point
+        >>> df, md = dataretrieval.wqp.get_results(
+        ...     lat='44.2', long='-88.9', within='0.5')
+
+        >>> # Get results within a bounding box
+        >>> df, md = dataretrieval.wqp.get_results(
+        ...     bBox='-92.8,44.2,-88.9,46.0')
+
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
     response = query(wqp_url('Result'), kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
@@ -74,7 +85,7 @@ def get_results(**kwargs):
 
 
 def what_sites(**kwargs):
-    """ Search WQP for sites within a region with specific data.
+    """Search WQP for sites within a region with specific data.
 
     Parameters
     ----------
@@ -86,15 +97,18 @@ def what_sites(**kwargs):
     df: ``pandas.DataFrame``
         Formatted data returned from the API query.
     md: :obj:`dataretrieval.utils.Metadata`
-        Custom ``dataretrieval`` metadata object pertaining to the query.
+        Custom metadata object pertaining to the query.
 
     Examples
     --------
-    .. doctest::
+    .. code::
+
+        >>> # Get sites within a radial distance of a point
+        >>> df, md = dataretrieval.wqp.what_sites(
+        ...     lat='44.2', long='-88.9', within='2.5')
 
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
 
     url = wqp_url('Station')
     response = query(url, payload=kwargs, delimiter=';')
@@ -105,7 +119,7 @@ def what_sites(**kwargs):
 
 
 def what_organizations(**kwargs):
-    """ Search WQP for organizations within a region with specific data.
+    """Search WQP for organizations within a region with specific data.
 
     Parameters
     ----------
@@ -117,14 +131,17 @@ def what_organizations(**kwargs):
     df: ``pandas.DataFrame``
         Formatted data returned from the API query.
     md: :obj:`dataretrieval.utils.Metadata`
-        Custom ``dataretrieval`` metadata object pertaining to the query.
+        Custom metadata object pertaining to the query.
 
     Examples
     --------
+    .. code::
+
+        >>> # Get all organizations in the WQP
+        >>> df, md = dataretrieval.wqp.what_organizations()
 
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
 
     url = wqp_url('Organization')
     response = query(url, payload=kwargs, delimiter=';')
@@ -135,7 +152,7 @@ def what_organizations(**kwargs):
 
 
 def what_projects(**kwargs):
-    """ Search WQP for projects within a region with specific data.
+    """Search WQP for projects within a region with specific data.
 
     Parameters
     ----------
@@ -147,14 +164,17 @@ def what_projects(**kwargs):
     df: ``pandas.DataFrame``
         Formatted data returned from the API query.
     md: :obj:`dataretrieval.utils.Metadata`
-        Custom ``dataretrieval`` metadata object pertaining to the query.
+        Custom metadata object pertaining to the query.
 
     Examples
     --------
+    .. code::
+
+        >>> # Get projects within a HUC region
+        >>> df, md = dataretrieval.wqp.what_projects(huc='19')
 
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
 
     url = wqp_url('Project')
     response = query(url, payload=kwargs, delimiter=';')
@@ -165,7 +185,7 @@ def what_projects(**kwargs):
 
 
 def what_activities(**kwargs):
-    """ Search WQP for activities within a region with specific data.
+    """Search WQP for activities within a region with specific data.
 
     Parameters
     ----------
@@ -177,14 +197,20 @@ def what_activities(**kwargs):
     df: ``pandas.DataFrame``
         Formatted data returned from the API query.
     md: :obj:`dataretrieval.utils.Metadata`
-        Custom ``dataretrieval`` metadata object pertaining to the query.
+        Custom metadata object pertaining to the query.
 
     Examples
     --------
+    .. code::
+
+        >>> # Get activities within Washington D.C.
+        >>> # during a specific time period
+        >>> df, md = dataretrieval.wqp.what_activities(
+        ...     statecode='US:11', startDateLo='12-30-2019',
+        ...     startDateHi='01-01-2020')
 
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
 
     url = wqp_url('Activity')
     response = query(url, payload=kwargs, delimiter=';')
@@ -195,7 +221,7 @@ def what_activities(**kwargs):
 
 
 def what_detection_limits(**kwargs):
-    """ Search WQP for result detection limits within a region with specific
+    """Search WQP for result detection limits within a region with specific
     data.
 
     Parameters
@@ -208,14 +234,20 @@ def what_detection_limits(**kwargs):
     df: ``pandas.DataFrame``
         Formatted data returned from the API query.
     md: :obj:`dataretrieval.utils.Metadata`
-        Custom ``dataretrieval`` metadata object pertaining to the query.
+        Custom metadata object pertaining to the query.
 
     Examples
     --------
+    .. code::
+
+        >>> # Get detection limits for Nitrite measurements in Rhode Island
+        >>> # between specific dates
+        >>> df, md = dataretrieval.wqp.what_detection_limits(
+        ...     statecode='US:44', characteristicName='Nitrite',
+        ...     startDateLo='01-01-2021', startDateHi='02-20-2021')
 
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
 
     url = wqp_url('ResultDetectionQuantitationLimit')
     response = query(url, payload=kwargs, delimiter=';')
@@ -226,7 +258,7 @@ def what_detection_limits(**kwargs):
 
 
 def what_habitat_metrics(**kwargs):
-    """ Search WQP for habitat metrics within a region with specific data.
+    """Search WQP for habitat metrics within a region with specific data.
 
     Parameters
     ----------
@@ -238,14 +270,18 @@ def what_habitat_metrics(**kwargs):
     df: ``pandas.DataFrame``
         Formatted data returned from the API query.
     md: :obj:`dataretrieval.utils.Metadata`
-        Custom ``dataretrieval`` metadata object pertaining to the query.
+        Custom metadata object pertaining to the query.
 
     Examples
     --------
+    .. code::
+
+        >>> # Get habitat metrics for a state (Rhode Island in this case)
+        >>> df, md = dataretrieval.wqp.what_habitat_metrics(
+        ...     statecode='US:44')
 
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
 
     url = wqp_url('BiologicalMetric')
     response = query(url, payload=kwargs, delimiter=';')
@@ -256,7 +292,7 @@ def what_habitat_metrics(**kwargs):
 
 
 def what_project_weights(**kwargs):
-    """ Search WQP for project weights within a region with specific data.
+    """Search WQP for project weights within a region with specific data.
 
     Parameters
     ----------
@@ -268,14 +304,20 @@ def what_project_weights(**kwargs):
     df: ``pandas.DataFrame``
         Formatted data returned from the API query.
     md: :obj:`dataretrieval.utils.Metadata`
-        Custom ``dataretrieval`` metadata object pertaining to the query.
+        Custom metadata object pertaining to the query.
 
     Examples
     --------
+    .. code::
+
+        >>> # Get project weights for a state (North Dakota in this case)
+        >>> # within a set time period
+        >>> df, md = dataretrieval.wqp.what_project_weights(
+        ...     statecode='US:38', startDateLo='01-01-2006',
+        ...     startDateHi='01-01-2009')
 
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
 
     url = wqp_url('ProjectMonitoringLocationWeighting')
     response = query(url, payload=kwargs, delimiter=';')
@@ -286,7 +328,7 @@ def what_project_weights(**kwargs):
 
 
 def what_activity_metrics(**kwargs):
-    """ Search WQP for activity metrics within a region with specific data.
+    """Search WQP for activity metrics within a region with specific data.
 
     Parameters
     ----------
@@ -298,14 +340,20 @@ def what_activity_metrics(**kwargs):
     df: ``pandas.DataFrame``
         Formatted data returned from the API query.
     md: :obj:`dataretrieval.utils.Metadata`
-        Custom ``dataretrieval`` metadata object pertaining to the query.
+        Custom metadata object pertaining to the query.
 
     Examples
     --------
+    .. code::
+
+        >>> # Get activity metrics for a state (North Dakota in this case)
+        >>> # within a set time period
+        >>> df, md = dataretrieval.wqp.what_activity_metrics(
+        ...     statecode='US:38', startDateLo='07-01-2006',
+        ...     startDateHi='12-01-2006')
 
     """
-    kwargs['zip'] = 'no'
-    kwargs['mimeType'] = 'csv'
+    kwargs = _alter_kwargs(kwargs)
 
     url = wqp_url('ActivityMetric')
     response = query(url, payload=kwargs, delimiter=';')
@@ -334,3 +382,22 @@ def set_metadata(response, **parameters):
     elif 'site_no' in parameters:
         md.site_info = lambda: what_sites(sites=parameters['site_no'])
     return md
+
+
+def _alter_kwargs(kwargs):
+    """Private function to manipulate **kwargs.
+
+    Not all query parameters are currently supported by ``dataretrieval``,
+    so this function is used to set some of them and raise warnings to the
+    user so they are aware of which are being hard-set.
+
+    """
+    if kwargs.get('zip', 'no') == 'yes':
+        warnings.warn('Compressed data not yet supported, zip set to no.')
+    kwargs['zip'] = 'no'
+
+    if kwargs.get('mimeType', 'csv') == 'geojson':
+        warnings.warn('GeoJSON not yet supported, mimeType set to csv.')
+    kwargs['mimeType'] = 'csv'
+
+    return kwargs

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -17,44 +17,53 @@ def get_results(**kwargs):
     """
     Parameters
     ----------
-    siteid : string
-        Concatenate an agency code, a hyphen ("-"), and a site-identification number.
-
-    statecode : string
-        Concatenate 'US', a colon (":"), and a FIPS numeric code (Example: Illinois is US:17)
-
-    countycode : string
-
-    huc : string
+    siteid: string
+        Concatenate an agency code, a hyphen ("-"), and a site-identification
+        number.
+    statecode: string
+        Concatenate 'US', a colon (":"), and a FIPS numeric code
+        (Example: Illinois is US:17)
+    countycode: string
+        A FIPS county code
+    huc: string
         One or more eight-digit hydrologic units, delimited by semicolons.
-
-    bBox : string
-        (Example: bBox=-92.8,44.2,-88.9,46.0)
-
-    lat : float
+    bBox: string
+        Bounding box (Example: bBox=-92.8,44.2,-88.9,46.0)
+    lat: float
         Latitude for radial search, expressed in decimal degrees, WGS84
-
-    long :
+    long: float
         Longitude for radial search
+    within: float
+        Distance for a radial search, expressed in decimal miles
+    pCode: string
+        One or more five-digit USGS parameter codes, separated by semicolons.
+        NWIS only.
+    startDateLo: string
+        Date of earliest desired data-collection activity,
+        expressed as 'MM-DD-YYYY'
+    startDateHi: string
+        Date of last desired data-collection activity,
+        expressed as 'MM-DD-YYYY'
+    characteristicName: string
+        One or more case-sensitive characteristic names, separated by
+        semicolons. (See https://www.waterqualitydata.us/public_srsnames/
+        for available characteristic names)
+    mimeType: string
+        String specifying the output format which is 'csv' by default but can
+        be 'geojson'
+    zip: string
+        Parameter to stream compressed data, if 'yes', or uncompressed data
+        if 'no'. Default is 'no'.
 
-    within :
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
 
-    pCode : string
-        One or more five-digit USGS parameter codes, separated by semicolons. NWIS only.
-
-    startDateLo : string
-        Date of earliest desired data-collection activity, expressed as MM-DD-YYYY
-
-    startDateHi : string
-        Date of last desired data-collection activity, expressed as MM-DD-YYYY
-
-    characteristicName : string
-        One or more case-sensitive characteristic names, separated by semicolons.
-        (See https://www.waterqualitydata.us/public_srsnames/ for available characteristic names)
-
-    mimeType : string (csv)
-
-    zip : string (yes or no)
+    Examples
+    --------
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
@@ -69,13 +78,26 @@ def what_sites(**kwargs):
 
     Parameters
     ----------
-    same as get_results
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
+
+    Examples
+    --------
+    .. doctest::
+
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
 
     url = wqp_url('Station')
-    response = query(url, payload = kwargs, delimiter = ';')
+    response = query(url, payload=kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
 
@@ -87,13 +109,25 @@ def what_organizations(**kwargs):
 
     Parameters
     ----------
-    same as get_results
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
+
+    Examples
+    --------
+
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
 
     url = wqp_url('Organization')
-    response = query(url, payload = kwargs, delimiter = ';')
+    response = query(url, payload=kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
 
@@ -105,13 +139,25 @@ def what_projects(**kwargs):
 
     Parameters
     ----------
-    same as get_results
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
+
+    Examples
+    --------
+
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
 
     url = wqp_url('Project')
-    response = query(url, payload = kwargs, delimiter = ';')
+    response = query(url, payload=kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
 
@@ -123,13 +169,25 @@ def what_activities(**kwargs):
 
     Parameters
     ----------
-    same as get_results
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
+
+    Examples
+    --------
+
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
 
     url = wqp_url('Activity')
-    response = query(url, payload = kwargs, delimiter = ';')
+    response = query(url, payload=kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
 
@@ -142,13 +200,25 @@ def what_detection_limits(**kwargs):
 
     Parameters
     ----------
-    same as get_results
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
+
+    Examples
+    --------
+
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
 
     url = wqp_url('ResultDetectionQuantitationLimit')
-    response = query(url, payload = kwargs, delimiter = ';')
+    response = query(url, payload=kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
 
@@ -160,13 +230,25 @@ def what_habitat_metrics(**kwargs):
 
     Parameters
     ----------
-    same as get_results
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
+
+    Examples
+    --------
+
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
 
     url = wqp_url('BiologicalMetric')
-    response = query(url, payload = kwargs, delimiter = ';')
+    response = query(url, payload=kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
 
@@ -178,13 +260,25 @@ def what_project_weights(**kwargs):
 
     Parameters
     ----------
-    same as get_results
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
+
+    Examples
+    --------
+
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
 
     url = wqp_url('ProjectMonitoringLocationWeighting')
-    response = query(url, payload = kwargs, delimiter = ';')
+    response = query(url, payload=kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
 
@@ -196,13 +290,25 @@ def what_activity_metrics(**kwargs):
 
     Parameters
     ----------
-    same as get_results
+    **kwargs: optional
+        Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
+
+    Returns
+    -------
+    df: ``pandas.DataFrame``
+        Formatted data returned from the API query.
+    md: :obj:`dataretrieval.utils.Metadata`
+        Custom ``dataretrieval`` metadata object pertaining to the query.
+
+    Examples
+    --------
+
     """
     kwargs['zip'] = 'no'
     kwargs['mimeType'] = 'csv'
 
     url = wqp_url('ActivityMetric')
-    response = query(url, payload = kwargs, delimiter = ';')
+    response = query(url, payload=kwargs, delimiter=';')
 
     df = pd.read_csv(StringIO(response.text), delimiter=',')
 
@@ -210,16 +316,21 @@ def what_activity_metrics(**kwargs):
 
 
 def wqp_url(service):
+    """Construct the WQP URL for a given service.
+    """
     base_url = 'https://www.waterqualitydata.us/data/'
     return '{}{}/Search?'.format(base_url, service)
 
 
 def set_metadata(response, **parameters):
-    md = set_md(response)
+    """ Set metadata for WQP data.
+    """
+    md = set_md(response)  # initialize dataretrieval metadata object
+    # populate the metadata using NWIS site information
     if 'sites' in parameters:
-        md.site_info = lambda : what_sites(sites=parameters['sites'])
+        md.site_info = lambda: what_sites(sites=parameters['sites'])
     elif 'site' in parameters:
-        md.site_info = lambda : what_sites(sites=parameters['site'])
+        md.site_info = lambda: what_sites(sites=parameters['site'])
     elif 'site_no' in parameters:
-        md.site_info = lambda : what_sites(sites=parameters['site_no'])
+        md.site_info = lambda: what_sites(sites=parameters['site_no'])
     return md

--- a/demos/hydroshare/USGS_dataretrieval_DailyValues_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_DailyValues_Examples.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# USGS dataretrieval Python Package `get_dv()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve daily streamflow data for a United States Geological Survey (USGS) monitoring site. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "is_executing": true,
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_dv()` function to retrieve daily streamflow data for a USGS monitoring site from NWIS. The following arguments are supported:\n",
+    "\n",
+    "Arguments (Additional arguments, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **sites** (string or list of strings): A list of USGS site identifiers for which to retrieve data.\n",
+    "* **parameterCd** (list of strings): A list of USGS parameter codes for which to retrieve data.\n",
+    "* **statCd** (list of strings): A list of USGS statistic codes for which to retrieve data.\n",
+    "* **start** (string): The beginning date for a period for which to retrieve data. If the waterdata parameter startDT is supplied, it will overwrite the start parameter.\n",
+    "* **end** (string): The ending date for a period for which to retrieve data. If the waterdata parameter endDT is supplied, it will overwrite the end parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Example 1: Get daily value data for a specific parameter at a single USGS NWIS monitoring site between a begin and end date."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Set the parameters needed to retrieve data\n",
+    "siteNumber = \"10109000\" # LOGAN RIVER ABOVE STATE DAM, NEAR LOGAN, UT\n",
+    "parameterCode = \"00060\" # Discharge\n",
+    "startDate = \"2020-10-01\"\n",
+    "endDate = \"2021-09-30\"\n",
+    "\n",
+    "# Retrieve the data\n",
+    "dailyStreamflow = nwis.get_dv(sites=siteNumber, parameterCd=parameterCode, start=startDate, end=endDate) \n",
+    "print(\"Retrieved \" + str(len(dailyStreamflow[0])) + \" data values.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_dv()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the daily values for the observed variable and time period requested. The data frame is indexed by the dates associated with the data values.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Display the data frame as a table\n",
+    "display(dailyStreamflow[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(dailyStreamflow[0].dtypes)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Get summary statistics for the daily streamflow values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "dailyStreamflow[0].describe()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Make a quick time series plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "ax = dailyStreamflow[0].plot(y='00060_Mean')\n",
+    "ax.set_xlabel('Date')\n",
+    "ax.set_ylabel('Streamflow (cfs)')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other part of the result returned from the `get_dv()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"The query URL used to retrieve the data from NWIS was: \" + dailyStreamflow[1].url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### Additional Examples\n",
+    "\n",
+    "Example 2: Get daily mean and max discharge and temperature values for a site between a begin and end date.\n",
+    "\n",
+    "Parameter Code: 00010 = temperature, 00060 = discharge\n",
+    "See https://help.waterdata.usgs.gov/codes-and-parameters/parameters\n",
+    "\n",
+    "Statistic Code: 00001 = Maximum, 00003 = Mean\n",
+    "See https://help.waterdata.usgs.gov/stat_code\n",
+    "\n",
+    "NOTE: There's not full overlap in the availability of data for temperature and discharge for both statistics at this site. When data for one statistic is not available, a \"NaN\" value is returned in the data frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "siteID = \"04085427\"\n",
+    "dailyQAndT = nwis.get_dv(sites=siteID, parameterCd=[\"00010\", \"00060\"],\n",
+    "                         start=startDate, end=endDate,\n",
+    "                         statCd=[\"00001\", \"00003\"])\n",
+    "display(dailyQAndT[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example 3: Get daily mean and max discharge and temperature values for multiple sites between a begin and end date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dailyMultiSites = nwis.get_dv(sites=[\"01491000\", \"01645000\"], parameterCd=[\"00010\", \"00060\"],\n",
+    "                              start=\"2012-01-01\", end=\"2012-06-30\", statCd=[\"00001\",\"00003\"])\n",
+    "display(dailyMultiSites[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example 4: Test for a site that is not active - returns an empty DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "siteID = \"05212700\"\n",
+    "notActive = nwis.get_dv(sites=siteID, parameterCd=\"00060\", start=\"2014-01-01\", end=\"2014-01-07\")\n",
+    "display(notActive[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/demos/hydroshare/USGS_dataretrieval_GroundwaterLevels_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_GroundwaterLevels_Examples.ipynb
@@ -1,0 +1,400 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_gwlevels()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve groundwater level data for a United States  Geological Survey (USGS) monitoring site. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_gwlevels()` function to retrieve groundwater level data from USGS NWIS. The following arguments are supported:\n",
+    "\n",
+    "Arguments (Additional parameters, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **sites** (string or list of strings): A list of USGS site identifiers for which to retrieve data.\n",
+    "* **start** (string): The beginning date for a period for which to retrieve data. If the waterdata parameter begin_date is supplied, it will overwrite the start parameter (defaults to '1851-01-01')\n",
+    "* **end** (string): The ending date for a period for which to retrieve data. If the waterdata parameter end_date is supplied, it will overwrite the end parameter."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Example 1: Get groundwater level data for a single monitoring site."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Set the parameters needed to retrieve data\n",
+    "site_id = \"434400121275801\"\n",
+    "\n",
+    "# Retrieve the data\n",
+    "data = nwis.get_gwlevels(sites=site_id)\n",
+    "print(\"Retrieved \" + str(len(data[0])) + \" data values.\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_gwlevels()` function is an object that contains a Pandas data frame and an associated metadata object. The Pandas data frame contains the data requested. The data frame is indexed by the dates associated with the data values.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Display the data frame as a table"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "display(data[0])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(data[0].dtypes)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Get summary statistics for the daily streamflow values."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "data[0]['lev_va'].describe()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Make a quick time series plot."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "ax = data[0].plot(y='lev_va')\n",
+    "ax.set_xlabel('Date')\n",
+    "ax.set_ylabel('Water Level (feet below land surface)')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The other part of the result returned from the `get_gwlevels()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(\"The query URL used to retrieve the data from  NWIS was: \" + data[1].url)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Additional Examples\n",
+    "\n",
+    "You can also request data for multiple sites at the same time.\n",
+    "\n",
+    "Example 2: Get data for multiple sites. Site numbers are specified using a comma delimited list of strings."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "site_ids = [\"434400121275801\", \"375907091432201\"]\n",
+    "data2 = nwis.get_gwlevels(sites=site_ids)\n",
+    "print(\"Retrieved \" + str(len(data2[0])) + \" data values.\")\n",
+    "display(data2[0])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Some groundwater level data have dates that include only a year or a month and year, but no day.\n",
+    "\n",
+    "Example 3: Retrieve groundwater level data that have dates without a day."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "data3 = nwis.get_gwlevels(sites=\"425957088141001\")\n",
+    "print(\"Retrieved \" + str(len(data3[0])) + \" data values.\")\n",
+    "\n",
+    "# Print the date/time index values, which show up as NaT because\n",
+    "# the dates can't be converted to a date/time data type\n",
+    "print(data3[0].index)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "If you want to see the USGS RDB (delimited text) version of the data just retrieved, you can get the URL for the request that was sent to the USGS web service."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Print the URL used to retrieve the data\n",
+    "print(\"You can examine the data retrieved from NWIS at: \" + data3[1].url)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "You can also retrieve data for a site within a specified time window by specifying a start date and an end date.\n",
+    "\n",
+    "Example 4: Get groundwater level data for a site between a startDate and endDate."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "data4 = nwis.get_gwlevels(sites=site_id, start=\"1980-01-01\", end=\"2000-12-31\")\n",
+    "print(\"Retrieved \" + str(len(data4[0])) + \" data values.\")\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/demos/hydroshare/USGS_dataretrieval_Measurements_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_Measurements_Examples.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_discharge_measurements()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve surface water discharge measurement data for a United States Geological Survey (USGS) monitoring site. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_discharge_measurements()` function to retrieve surface water discharge measurements for a USGS monitoring site from NWIS. The function has the following arguments:\n",
+    "\n",
+    "Arguments (Additional arguments, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **sites** (list of strings): A list of USGS site codes to retrieve data for. If the qwdata parameter site_no is supplied, it will overwrite the sites parameter.\n",
+    "* **start** (string): The beginning date of a period for which to retrieve measurements. If the qwdata parameter begin_date is supplied, it will overwrite the start parameter.\n",
+    "* **end** (string): The ending date of a period for which to retrieve measurements. If the qwdata parameter end_date is supplied, it will overwrite the end parameter."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Example 1: Get all of the surface water measurements for a single site"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "measurements1 = nwis.get_discharge_measurements(sites=\"10109000\")\n",
+    "print(\"Retrieved \" + str(len(measurements1[0])) + \" data values.\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_discharge_measurements()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the discharge measurements for the time period requested.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Display the data frame as a table"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "display(measurements1[0])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(measurements1[0].dtypes)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The other part of the result returned from the `get_discharge_measurements()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(\"The query URL used to retrieve the data from NWIS was: \" + measurements1[1].url)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Additional Examples\n",
+    "\n",
+    "Example 2: Get all of the surface water measurements between a start and end date"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "measurements2 = nwis.get_discharge_measurements(sites=\"10109000\", start=\"2019-01-01\", end=\"2019-12-31\")\n",
+    "print(\"Retrieved \" + str(len(measurements2[0])) + \" data values.\")\n",
+    "display(measurements2[0])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Example 3: Get all of the surface water measurements for multiple sites"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "measurements3 = nwis.get_discharge_measurements(sites=[\"01594440\", \"040851325\"])\n",
+    "print(\"Retrieved \" + str(len(measurements3[0])) + \" data values.\")\n",
+    "display(measurements3[0])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/demos/hydroshare/USGS_dataretrieval_ParameterCodes_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_ParameterCodes_Examples.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_pmcodes()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve information about USGS parameter codes from NWIS. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA).\n",
+    "\n",
+    "For more information about USGS NWIS parameter codes, see:\n",
+    "https://help.waterdata.usgs.gov/codes-and-parameters/parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_pmcodes()` function to retrieve information about parameter codes (i.e., observed variables) from NWIS. The following arguments are supported:\n",
+    "\n",
+    "Arguments (Additional arguments, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **parameterCd** (string): A string containing the parameter code for which information is to be retrieved."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Example 1: Retrieve information for a set of USGS NWIS parameter codes."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "parameter_codes = nwis.get_pmcodes(['00400'])\n",
+    "print(\"Retrieved information about \" + str(len(parameter_codes[0])) + \" parameter code.\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_pmcodes()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the parameter code information requested.\n",
+    "\n",
+    "Once you've got the data frame, you can explore the data."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Display the data frame as a table\n",
+    "display(parameter_codes[0])\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/demos/hydroshare/USGS_dataretrieval_Peaks_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_Peaks_Examples.ipynb
@@ -1,0 +1,272 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_discharge_peaks()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve streamflow peak data for United States Geological Survey (USGS) monitoring sites. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_discharge_peaks()` function to retrieve peak streamflow data for a USGS monitoring site from NWIS. The function has the following arguments:\n",
+    "\n",
+    "Arguments (Additional parameters, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **sites** (list of strings): A list of USGS site identifiers for which data will be retrieved. If the waterdata parameter site_no is supplied, it will overwrite the sites parameter.\n",
+    "* **start** (string): A beginning date for the period for which data will be retrieved. If the waterdata parameter begin_date is supplied, it will overwrite the start parameter.\n",
+    "* **end** (string): An ending date for the period for which data will be retrieved. If the waterdata parameter end_date is supplied, it will overwrite the end parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example 1: Retrieve streamflow peak data for two USGS monitoring sites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "site_ids = ['01594440', '040851325']\n",
+    "peak_data = nwis.get_discharge_peaks(site_ids)\n",
+    "print(\"Retrieved \" + str(len(peak_data[0])) + \" data values.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_discharge_peaks()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the discharge peak values for the requested site(s).\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data.\n",
+    "\n",
+    "Display the data frame as a table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "display(peak_data[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(peak_data[0].dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other part of the result returned from the `get_dv()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"The query URL used to retrieve the data from NWIS was: \" + peak_data[1].url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Additional Examples\n",
+    "\n",
+    "Example 2: Retrieve discharge peaks for a single site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stations = \"06011000\"\n",
+    "data3 = nwis.get_discharge_peaks(stations)\n",
+    "display(data3[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Example 3: Retrieve peak discharge data for a monitoring site between two dates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "data4 = nwis.get_discharge_peaks(stations, start='1953-01-01', end='1960-01-01')\n",
+    "display(data4[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/demos/hydroshare/USGS_dataretrieval_Ratings_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_Ratings_Examples.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# USGS dataretrieval Python Package `get_ratings()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve rating curve data for a United States Geological Survey (USGS) streamflow gage. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This example uses the `get_ratings()` function to retrieve rating curve data for a monitoring site from USGS NWIS. The following arguments are available:\n",
+    "\n",
+    "Arguments (Additional arguments, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **site** (string): A USGS site number.  This is usually an 8 digit number as a string. If the nwis parameter site_no is supplied, it will overwrite the site parameter.\n",
+    "* **base** (string): Can be \"base\", \"corr\", or \"exsa\"\n",
+    "* **county** (string): County IDs from county lookup or \"ALL\"\n",
+    "* **categories** (Listlike): List or comma delimited string of Two-letter category abbreviations\n",
+    "\n",
+    "NOTE: Not all active USGS streamflow gages have traditional rating curves that relate stage to flow."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Example 1: Get rating data for an NWIS Site"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Specify the USGS site number/code\n",
+    "site_id = \"10109000\"\n",
+    "\n",
+    "# Get the rating curve data\n",
+    "ratingData = nwis.get_ratings(site=site_id, file_type=\"exsa\")\n",
+    "print(\"Retrieved \" + str(len(ratingData[0])) + \" data values.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_ratings()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the rating curve data for the requested site.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data. You can execute the following code to display the data frame as a table.\n",
+    "\n",
+    "If the \"type\" parameter in the request has a value of \"base,\" then the columns in the data frame are as follows:\n",
+    "* INDEP - typically the gage height in feet\n",
+    "* DEP - typically the streamflow in cubic feet per second\n",
+    "* STOR - where an \"*\" indicates that the pair are a fixed point of the rating curve\n",
+    "\n",
+    "If the \"type\" parameter is specified as \"exsa,\" then an additional column called SHIFT is included that indicates the current shift in the rating for that value of INDEP.\n",
+    "\n",
+    "If the \"type\" parameter is specified as \"corr,\" then the columns are as follows:\n",
+    "* INDEP - typically gage height in feet\n",
+    "* CORR - the correction for that value\n",
+    "* CORRINDEP - the corrected value for CORR"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "display(ratingData[0])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Show the data types of the columns in the resulting data frame"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(ratingData[0].dtypes)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The other part of the result returned from the `get_ratings()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(\"The query URL used to retrieve the data from NWIS was: \" + ratingData[1].url)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Example 2: Get rating data for a different NWIS site by changing the site_id"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "site_id = '01594440'\n",
+    "data = nwis.get_ratings(site=site_id, file_type=\"base\")\n",
+    "print(\"Retrieved \" + str(len(data[0])) + \" data values.\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/demos/hydroshare/USGS_dataretrieval_SiteInfo_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_SiteInfo_Examples.ipynb
@@ -1,0 +1,301 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_info()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve information about a United States Geological Survey (USGS) monitoring site. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_info()` function to retrieve information about USGS monitoring sites. The function has several arguments, depending on the result you want to retrieve:\n",
+    "\n",
+    "#### Major Arguments (Additional arguments, if supplied, will be used as query parameters)\n",
+    "\n",
+    "Note: Must specify one major argument.\n",
+    "\n",
+    "* **sites** (string or list of strings): A list of site numbers. Sites may be prefixed with an optional agency code followed by a colon.\n",
+    "* **stateCd** (string): U.S. postal service (2-digit) state code. Only 1 state can be specified per request.\n",
+    "* **huc** (string or list of strings): A list of hydrologic unit codes (HUC) or aggregated watersheds. Only 1 major HUC can be specified per request, or up to 10 minor HUCs. A major HUC has two digits.\n",
+    "* **bBox** (list): A contiguous range of decimal latitude and longitude, starting with the west longitude, then the south latitude, then the east longitude, and then the north latitude with each value separated by a comma. The product of the range of latitude range and longitude cannot exceed 25 degrees. Whole or decimal degrees must be specified, up to six digits of precision. Minutes and seconds are not allowed.\n",
+    "* **countyCd** (string or list of strings): A list of county numbers, in a 5 digit numeric format. The first two digits of a county's code are the FIPS State Code. (url: https://help.waterdata.usgs.gov/code/county_query?fmt=html)\n",
+    "\n",
+    "#### Minor Arguments\n",
+    "\n",
+    "* **startDt** (string): Selects sites based on whether data was collected at a point in time beginning after startDt (start date). Dates must be in ISO-8601 Calendar Date format (for example: 1990-01-01).\n",
+    "* **endDt** (string)\n",
+    "* **period** (string): Selects sites based on whether or not they were active between now and a time in the past. For example, period=P10W will select sites active in the last ten weeks.\n",
+    "* **modifiedSince** (string): Returns only sites where site attributes or period of record data have changed during the request period.\n",
+    "* **parameterCd** (string or list of strings): Returns only site data for those sites containing the requested USGS parameter codes.\n",
+    "* **siteType** (string or list of strings): Restricts sites to those having one or more major and/or minor site types, such as stream, spring or well. For a list of all valid site types see https://help.waterdata.usgs.gov/site_tp_cd. For example, siteType='ST' returns streams only.\n",
+    "\n",
+    "#### Formatting Parameters\n",
+    "\n",
+    "NOTE: The following parameters are available via the USGS data retrieval services, but are not yet functional in the dataretrieval Python package\n",
+    "\n",
+    "* **siteOutput** (string 'basic' or 'expanded'): Indicates the richness of metadata you want for site attributes. Note that for visually oriented formats like Google Map format, this argument has no meaning. Note: for performance reasons, siteOutput='expanded' cannot be used if seriesCatalogOutput=true or with any values for outputDataTypeCd.\n",
+    "* **seriesCatalogOutput** (boolean): A switch that provides detailed period of record information for certain output formats. The period of record indicates date ranges for a certain kind of information about a site, for example the start and end dates for a site's daily mean streamflow.\n",
+    "\n",
+    "For additional parameter options see https://waterservices.usgs.gov/rest/Site-Service.html#stateCd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 1: Get site information for a USGS NWIS monitoring site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Specify the site you want to retrieve information for\n",
+    "siteID = \"10109000\"\n",
+    "\n",
+    "# Get the site information\n",
+    "siteINFO = nwis.get_info(sites=siteID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_info()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the site information for the requested site.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the information about the site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Display the data frame as a table\n",
+    "display(siteINFO[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(siteINFO[0].dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other part of the result returned from the `get_info()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"The query URL used to retrieve the data from NWIS was: \" + siteINFO[1].url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Additional Examples\n",
+    "\n",
+    "#### Example 2: Get site information for multiple sites in a list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Create a list of the site identifiers you want to retrieve information for\n",
+    "siteIDs = [\"05114000\", \"09423350\"]\n",
+    "\n",
+    "# Get the site information\n",
+    "siteINFO_multi = nwis.get_info(sites=siteIDs)\n",
+    "display(siteINFO_multi[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 3: Get site information for all sites within a state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the site information for a state\n",
+    "siteINFO_state = nwis.get_info(stateCd='UT')\n",
+    "display(siteINFO_state[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 4: Get site information for all \"stream\" sites within a USGS HUC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a list of hucs for which to query sites\n",
+    "huc_list = ['16010203']\n",
+    "\n",
+    "# Get the site information - limit to stream sites\n",
+    "siteINFO_huc = nwis.get_info(huc=huc_list, siteType='ST')\n",
+    "display(siteINFO_huc[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/demos/hydroshare/USGS_dataretrieval_SiteInventory_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_SiteInventory_Examples.ipynb
@@ -1,0 +1,297 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `what_sites()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to search NWIS for sites within a region with specific data. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `what_sites()` function to search NWIS for sites within a region with specific data. The function has several arguments, depending on the result you want to retrieve.\n",
+    "\n",
+    "Note: Must specify one major argument.\n",
+    "\n",
+    "#### Major Arguments (Additional arguments, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **sites** (string or list): A list of site numbers. Sites may be prefixed with an optional agency code followed by a colon.\n",
+    "* **stateCd** (string): U.S. postal service (2-digit) state code. Only 1 state can be specified per request.\n",
+    "* **huc** (string or list): A list of hydrologic unit codes (HUC) or aggregated watersheds. Only 1 major HUC can be specified per request, or up to 10 minor HUCs. A major HUC has two digits.\n",
+    "* **bBox** (list): A contiguous range of decimal latitude and longitude, starting with the west longitude, then the south latitude, then the east longitude, and then the north latitude with each value separated by a comma. The product of the range of latitude range and longitude cannot exceed 25 degrees. Whole or decimal degrees must be specified, up to six digits of precision. Minutes and seconds are not allowed.\n",
+    "* **countyCd** (string or list): A list of county numbers, in a 5 digit numeric format. The first two digits of a county's code are the FIPS State Code. (url: https://help.waterdata.usgs.gov/code/county_query?fmt=html)\n",
+    "\n",
+    "#### Minor Arguments\n",
+    "\n",
+    "* **startDt** (string): Selects sites based on whether data was collected at a point in time beginning after startDt (start date). Dates must be in ISO-8601 Calendar Date format (for example: 1990-01-01).\n",
+    "* **endDt** (string)\n",
+    "* **period** (string): Selects sites based on whether or not they were active between now and a time in the past. For example, period=P10W will select sites active in the last ten weeks.\n",
+    "* **modifiedSince** (string): Returns only sites where site attributes or period of record data have changed during the request period.\n",
+    "* **parameterCd** (string or list): Returns only site data for those sites containing the requested USGS parameter codes.\n",
+    "* **siteType** (string or list): Restricts sites to those having one or more major and/or minor site types, such as stream, spring or well. For a list of all valid site types see https://help.waterdata.usgs.gov/site_tp_cd. For example, siteType='ST' returns streams only.\n",
+    "\n",
+    "#### Formatting Parameters\n",
+    "\n",
+    "* **siteOutput** (string 'basic' or 'expanded'): Indicates the richness of metadata you want for site attributes. Note that for visually oriented formats like Google Map format, this argument has no meaning. Note: for performance reasons, siteOutput='expanded' cannot be used if seriesCatalogOutput=true or with any values for outputDataTypeCd.\n",
+    "* **seriesCatalogOutput** (boolean): A switch that provides detailed period of record information for certain output formats. The period of record indicates date ranges for a certain kind of information about a site, for example the start and end dates for a site's daily mean streamflow.\n",
+    "\n",
+    "For additional parameter options see https://waterservices.usgs.gov/rest/Site-Service.html#stateCd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 1: Retrieve information about sites in Ohio where phosphorus data was collected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "siteListPhos = nwis.what_sites(stateCd=\"OH\", parameterCd=\"00665\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `what_sites()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the requestes site inventory data.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Display the data frame as a table\n",
+    "display(siteListPhos[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "The other part of the result returned from the `what_sites()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print('The query URL used to retrieve the data from NWIS was: ' + siteListPhos[1].url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Additional Examples\n",
+    "\n",
+    "#### Example 2: Retrieve site information for a single site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "oneSite = nwis.what_sites(sites='05114000')\n",
+    "display(oneSite[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 3: Retrieve site information for a single site and show the result with expanded output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oneSite = nwis.what_sites(sites='05114000', siteOutput='expanded')\n",
+    "display(oneSite[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 4: Retrieve site information for sites in Utah with daily values data falling within a specified date range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "UTsites = nwis.what_sites(stateCd='UT', outputDataTypeCd='dv', startDT='1971-07-01', endDT='2021-07-28')\n",
+    "display(UTsites[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 5: Retrieve site information for a single site and show the series catalog output\n",
+    "\n",
+    "The series catalog output is a list of the parameters that have been collected at that site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oneSite = nwis.what_sites(sites='05114000', seriesCatalogOutput='true')\n",
+    "display(oneSite[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/demos/hydroshare/USGS_dataretrieval_Statistics_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_Statistics_Examples.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_stats()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve statistics for observed variables at a United States Geological Survey (USGS) monitoring site. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display\n",
+    "from matplotlib import ticker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_stats()` function to retrieve statistics for observed variable(s) for a USGS monitoring site from USGS NWIS. The following arguments are available:\n",
+    "\n",
+    "Arguments (Additional parameters, if supplied, will be used as query parameters).\n",
+    "\n",
+    "* **sites** (string or list of strings): A string or list of strings contining the USGS site identifiers for which to retrive data.\n",
+    "* **parameterCd** (string or list of strings): A list of USGS parameter codes for which to retrieve data.\n",
+    "* **statReportType** (string): The aggregation period for which statistics should be reported. Can be specified as 'daily' (default), 'monthly', or 'annual'.\n",
+    "* **statTypeCd** (string): The type of statistic to be returned in the result. Can be specified as 'all', 'mean', 'max', 'min', or 'median'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 1: Get all of the annual mean discharge data for a single site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Set the parameters needed to retrieve data\n",
+    "siteNumber = \"02319394\"\n",
+    "parameterCode = \"00060\" # Discharge\n",
+    "\n",
+    "# Retrieve the statistics\n",
+    "x1 = nwis.get_stats(sites=siteNumber, parameterCd=parameterCode, statReportType=\"annual\")\n",
+    "print(\"Retrieved \" + str(len(x1[0])) + \" data values.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_stats()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the statistics values for the site and observed variable requested.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Display the data frame as a table\n",
+    "display(x1[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(x1[0].dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a quick time series plot of the annual mean values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ax = x1[0].plot(x='year_nu', y='mean_va')\n",
+    "ax.xaxis.set_major_formatter(ticker.FormatStrFormatter('%d'))\n",
+    "ax.set_xlabel('Year')\n",
+    "ax.set_ylabel('Annual mean discharge (cfs)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other part of the result returned from the `get_stats()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"The query URL used to retrieve the data from NWIS was: \" + x1[1].url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Additional Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 2: Get all of the annual mean discharge data for two sites\n",
+    "\n",
+    "Note: Passing multiple parameters (temperature and flow) looks like it returns only what is available (in this example flow, 00060)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "x2 = nwis.get_stats(sites=[\"02319394\", \"02171500\"], parameterCd=[\"00010\", \"00060\"],\n",
+    "                    statReportType=\"annual\")\n",
+    "display(x2[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 3: Request daily mean and median values for temperature and discharge for a site for years between 2000 and 2007\n",
+    "\n",
+    "NOTE: The startDt and endDt parameters are not directly supported by this function but are turned into query parameters in the request to USGS NWIS, which means that they can be used to limit the time window requested."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "x3 = nwis.get_stats(sites=\"02171500\", parameterCd=[\"00010\", \"00060\"],\n",
+    "                    statReportType=\"daily\", statTypeCd=[\"mean\", \"median\"],\n",
+    "                    startDt=\"2000\", endDt=\"2007\")\n",
+    "display(x3[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/demos/hydroshare/USGS_dataretrieval_UnitValues_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_UnitValues_Examples.ipynb
@@ -1,0 +1,392 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_iv()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve instantaneous values data for a United States Geological Survey (USGS) monitoring site. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display\n",
+    "from datetime import date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This example uses the `get_iv()` function to retrieve instantaneous streamflow data for a USGS monitoring site from NWIS. The following arguments are supported:\n",
+    "\n",
+    "* **sites** (string or list of strings): A list of USGS site identifiers for which to retrieve data.\n",
+    "* **parameterCd** (string or list of strings): A list of USGS parameter codes for which to retrieve data.\n",
+    "* **start** (string): The beginning date for a period for which to retrieve data. If the waterdata parameter startDt is supplied, it will overwrite the start parameter.\n",
+    "* **end** (string): The ending date for a period for which to retrieve data. If the waterdata parameter endDt is supplied, it will overwrite the end parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 1: Get unit value data for a specific parameter at a USGS NWIS monitoring site between a begin and end date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Set the parameters needed for the web service call\n",
+    "siteID = '10109000'  # LOGAN RIVER ABOVE STATE DAM, NEAR LOGAN, UT\n",
+    "parameterCode = '00060'  # Discharge\n",
+    "startDate = '2021-09-01'\n",
+    "endDate = '2021-09-30'\n",
+    "\n",
+    "# Get the data\n",
+    "discharge = nwis.get_iv(sites=siteID, parameterCd=parameterCode, start=startDate, end=endDate)\n",
+    "print('Retrieved ' + str(len(discharge[0])) + ' data values.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_iv()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the values for the observed variable and time period requested. The data frame is indexed by the dates associated with the data values.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Display the data frame as a table\n",
+    "display(discharge[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(discharge[0].dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get summary statistics for the daily streamflow values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "discharge[0].describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a quick time series plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ax = discharge[0].plot(y='00060')\n",
+    "ax.set_xlabel('Date')\n",
+    "ax.set_ylabel('Streamflow (cfs)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other part of the result returned from the `get_iv()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print('The query URL used to retrieve the data from NWIS was: ' + discharge[1].url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Additional Examples\n",
+    "\n",
+    "#### Example 2: Get unit values for an individual site and parameter between a start and end date.\n",
+    "\n",
+    "NOTE: By default, start and end date are evaluated as local time, and the result is returned with the timestamps in the local time of the monitoring site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "site_id = '05114000'\n",
+    "startDate = '2014-10-10'\n",
+    "endDate = '2014-10-10'\n",
+    "\n",
+    "discharge2 = nwis.get_iv(sites=site_id, parameterCd=parameterCode, start=startDate, end=endDate)\n",
+    "print('Retrieved ' + str(len(discharge2[0])) + ' data values.')\n",
+    "display(discharge2[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 3: Get unit values for an individual site for today"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "today = str(date.today())\n",
+    "discharge_today = nwis.get_iv(sites=site_id, parameterCd=parameterCode, start=today, end=today)\n",
+    "print('Retrieved ' + str(len(discharge_today[0])) + ' data values.')\n",
+    "display(discharge_today[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 4: Retrieve data using UTC times\n",
+    "\n",
+    "NOTE: Adding 'Z' to the input time parameters indicates that they are in UTC rather than local time. The time stamps associated with the data returned are still in the local time of the USGS monitoring site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "discharge_UTC = nwis.get_iv(sites=site_id, parameterCd=parameterCode,\n",
+    "                            start='2014-10-10T00:00Z', end='2014-10-10T23:59Z')\n",
+    "print('Retrieved ' + str(len(discharge_UTC[0])) + ' data values.')\n",
+    "display(discharge_UTC[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 5: Get unit values for two sites, for a single parameter, between a start and end date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "discharge_multisite = nwis.get_iv(sites=['04024430', '04024000'], parameterCd=parameterCode,\n",
+    "                                  start='2013-10-01', end='2013-10-01')\n",
+    "print('Retrieved ' + str(len(discharge_multisite[0])) + ' data values.')\n",
+    "display(discharge_multisite[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/demos/hydroshare/USGS_dataretrieval_WaterSamples_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_WaterSamples_Examples.ipynb
@@ -1,0 +1,306 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_qwdata()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve water quality sample data for United States Geological Survey (USGS) monitoring sites. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_qwdata()` function to retrieve water quality sample data for USGS monitoring sites from NWIS. The following arguments are supported:\n",
+    "\n",
+    "Arguments (Additional arguments, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **sites** (string or list of strings): A list of USGS site identifiers for which to retrieve data. If the qwdata parameter site_no is supplied, it will overwrite the sites parameter.\n",
+    "* **parameterCd** (string or list of strings): A list of USGS parameter codes for which to retrieve data.\n",
+    "* **start** (string): The beginning date for a period for which to retrieve data. If the qwdata parameter begin_date is supplied, it will overwrite the start parameter.\n",
+    "* **end** (string): The ending date for a period for which to retrieve data. If the qwdata parameter end_date is supplied, it will overwrite the end parameter.\n",
+    "* **datetime_index** (boolean): If True, create a datetime index\n",
+    "* **wide_format** (boolean): If True, return data in wide format with multiple samples per row and one row per time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 1: Get all water quality sample data for a single monitoring site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "siteID = '10109000'\n",
+    "wq_data = nwis.get_qwdata(sites=siteID)\n",
+    "print('Retrieved data for ' + str(len(wq_data[0])) + ' samples.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_qwdata()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the water quality sample data for the requested site, and or observed variables and time frame.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Display the data frame as a table. The default data frame for this function is a  wide, cross-tabulated table, with columns for each observed variable and a row for each sample date (wide_format=True)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "display(wq_data[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(wq_data[0].dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other part of the result returned from the `get_qwdata()` function is a metadata object that contains information about the query that was executed to return the data. For example, you can access the URL that was assembled to retrieve the requested data from the USGS web service. The USGS web service responses contain a descriptive header that defines and can be helpful in interpreting the contents of the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print('The query URL used to retrieve the data from NWIS was: ' + wq_data[1].url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Additional Examples\n",
+    "\n",
+    "#### Example 2: Get water quality sample data for multiple sites for a single parameter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "site_ids = ['04024430', '04024000']\n",
+    "parameter_code = '00065'\n",
+    "wq_multi_site = nwis.get_qwdata(sites=site_ids, parameterCd=parameter_code)\n",
+    "print('Retrieved data for ' + str(len(wq_multi_site[0])) + ' samples.')\n",
+    "display(wq_multi_site[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 3: Retrieve water quality sample data for multiple sites, including a list of parameters, within a time period defined by start and end dates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "site_ids = ['04024430', '04024000']\n",
+    "parameterCd = ['34247', '30234', '32104', '34220']\n",
+    "startDate = '2012-01-01'\n",
+    "endDate = ''\n",
+    "wq_data2 = nwis.get_qwdata(sites=site_ids, parameterCd=parameterCd,\n",
+    "                           start=startDate, end=endDate)\n",
+    "print('Retrieved data for ' + str(len(wq_multi_site[0])) + ' samples.')\n",
+    "display(wq_data2[0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 4: Retrieve water quality sample data for one site in serial format\n",
+    "\n",
+    "Each row in the resulting table represents a single observation of a single parameters. Each sample may be analyzed for multiple parameters and so a single water quality sample can result in multiple rows in serial format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "siteID = '10109000'\n",
+    "wq_data = nwis.get_qwdata(sites=siteID, wide_format=False)\n",
+    "print('Retrieved data for ' + str(len(wq_data[0])) + ' sample results.')\n",
+    "display(wq_data[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/demos/hydroshare/USGS_dataretrieval_WaterUse_Examples.ipynb
+++ b/demos/hydroshare/USGS_dataretrieval_WaterUse_Examples.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# USGS dataretrieval Python Package `get_water_use()` Examples\n",
+    "\n",
+    "This notebook provides examples of using the Python dataretrieval package to retrieve water use data. The dataretrieval package provides a collection of functions to get data from the USGS National Water Information System (NWIS) and other online sources of hydrology and water quality data, including the United States Environmental Protection Agency (USEPA)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the Package\n",
+    "\n",
+    "Use the following code to install the package if it doesn't exist already within your Jupyter Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install dataretrieval"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the package so you can use it along with other packages used in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dataretrieval import nwis\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic Usage\n",
+    "\n",
+    "The dataretrieval package has several functions that allow you to retrieve data from different web services. This examples uses the `get_water_use()` function to retrieve water use data. The following arguments are supported:\n",
+    "\n",
+    "Arguments (Additional arguments, if supplied, will be used as query parameters)\n",
+    "\n",
+    "* **years** (Listlike): List or comma delimited string of years.  Must be years ending in 0 or 5 because water use data is only reported during these years, or \"ALL\", which retrieves all available years\n",
+    "* **state** (string): Full name, abbreviation or id for a state for which to retrieve data\n",
+    "* **county** (string or list of strings): County IDs from county lookup or \"ALL\"\n",
+    "* **categories** (Listlike): List or comma delimited string of two-letter category abbreviations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 1: Retrieve all water use data for a state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pennsylvania = nwis.get_water_use(state='PA')\n",
+    "print('Retrieved ' + str(len(pennsylvania[0])) + ' water use records.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpreting the Result\n",
+    "\n",
+    "The result of calling the `get_water_use()` function is an object that contains a Pandas data frame object and an associated metadata object. The Pandas data frame contains the water use data.\n",
+    "\n",
+    "Once you've got the data frame, there's several useful things you can do to explore the data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Display the data frame as a table. The example request was for a whole state. The data returned are organized by county and year, with summary data reported every 5 years."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "display(pennsylvania[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the data types of the columns in the resulting data frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(pennsylvania[0].dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 2: Retrieve data for an entire state for certain years\n",
+    "\n",
+    "Returns data parsed by county - one row for each county for each year of interest rather than the entire state. Data are included for 5 year periods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ohio = nwis.get_water_use(years=[2000, 2005, 2010], state='OH')\n",
+    "print('Retrieved ' + str(len(ohio[0])) + ' water use records.')\n",
+    "display(ohio[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "#### Example 3: Retrieve two specific water use categories for an entire state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Get water use data for livestock (LI) and irrigation (IT)\n",
+    "kansas = nwis.get_water_use(state='KS', categories=['IT', 'LI'])\n",
+    "print('Retrieved ' + str(len(kansas[0])) + ' water use records.')\n",
+    "display(kansas[0])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # Since we aren't installing package here, we mock imports of the dependencies.
 
-# Relative paths so docunentation can reference and include demos folder
+# Relative paths so documentation can reference and include demos folder
 import os
 import sys
 
@@ -92,6 +92,7 @@ doctest_global_setup = '''
 import dataretrieval
 import numpy as np
 import pandas as pd
+import matplotlib
 '''
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,5 +122,6 @@ html_static_path = ['_static']
 linkcheck_ignore = [
     r'https://streamstats.usgs.gov/streamstatsservices/#/',
     r'https://www.waterqualitydata.us/public_srsnames/',
-    r'https://waterqualitydata.us'
+    r'https://waterqualitydata.us',
+    r'https://github.com/USGS-python/dataretrieval/tree/master/demos/hydroshare'
 ]

--- a/docs/source/examples/USGS_dataretrieval_DailyValues_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_DailyValues_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_DailyValues_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_GroundwaterLevels_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_GroundwaterLevels_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_GroundwaterLevels_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_Measurements_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_Measurements_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_Measurements_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_ParameterCodes_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_ParameterCodes_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_ParameterCodes_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_Peaks_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_Peaks_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_Peaks_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_Ratings_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_Ratings_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_Ratings_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_SiteInfo_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_SiteInfo_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_SiteInfo_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_SiteInventory_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_SiteInventory_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_SiteInventory_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_Statistics_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_Statistics_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_Statistics_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_UnitValues_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_UnitValues_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_UnitValues_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_WaterSamples_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_WaterSamples_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_WaterSamples_Examples.ipynb"
+}

--- a/docs/source/examples/USGS_dataretrieval_WaterUse_Examples.nblink
+++ b/docs/source/examples/USGS_dataretrieval_WaterUse_Examples.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../demos/hydroshare/USGS_dataretrieval_WaterUse_Examples.ipynb"
+}

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -13,6 +13,37 @@ Simple uses of the ``dataretrieval`` package
     readme_examples
     siteinfo_examples
 
+
+Example Notebooks from Hydroshare
+---------------------------------
+A set of Jupyter Notebooks with Python code examples on how to use the
+``dataretrieval`` package are available on the `Hydroshare`_ platform.
+We provide executed versions of these notebooks below; to download the
+``.ipynb`` files for your own use, either visit the `Hydroshare`_ repository,
+or navigate to the `demos/hydroshare`_ subdirectory of the ``dataretrieval``
+project repository.
+
+.. _Hydroshare: https://www.hydroshare.org/resource/c97c32ecf59b4dff90ef013030c54264/
+
+.. _demos/hydroshare: https://github.com/USGS-python/dataretrieval/tree/master/demos/hydroshare
+
+.. toctree::
+    :maxdepth: 1
+
+    USGS_dataretrieval_DailyValues_Examples
+    USGS_dataretrieval_GroundwaterLevels_Examples
+    USGS_dataretrieval_Measurements_Examples
+    USGS_dataretrieval_ParameterCodes_Examples
+    USGS_dataretrieval_Peaks_Examples
+    USGS_dataretrieval_Ratings_Examples
+    USGS_dataretrieval_SiteInfo_Examples
+    USGS_dataretrieval_SiteInventory_Examples
+    USGS_dataretrieval_Statistics_Examples
+    USGS_dataretrieval_UnitValues_Examples
+    USGS_dataretrieval_WaterSamples_Examples
+    USGS_dataretrieval_WaterUse_Examples
+
+
 Using ``dataretrieval`` to obtain nation trends in peak annual streamflow
 -------------------------------------------------------------------------
 

--- a/docs/source/examples/readme_examples.rst
+++ b/docs/source/examples/readme_examples.rst
@@ -43,7 +43,7 @@ Examples from the Readme file on retrieving NWIS data
     >>> df3 = nwis.get_record(sites=site, service='site')
 
     >>> print(df3)
-      agency_cd   site_no                         station_nm site_tp_cd  lat_va  ...  aqfr_type_cd  well_depth_va  hole_depth_va depth_src_cd project_no
-    0      USGS  03339000  VERMILION RIVER NEAR DANVILLE, IL         ST  400603  ...           NaN            NaN            NaN          NaN        100
+      agency_cd   site_no                         station_nm site_tp_cd  lat_va  long_va  ...  aqfr_cd  aqfr_type_cd well_depth_va hole_depth_va depth_src_cd project_no
+    0      USGS  03339000  VERMILION RIVER NEAR DANVILLE, IL         ST  400603   873550  ...      NaN           NaN           NaN           NaN          NaN        100
     <BLANKLINE>
     [1 rows x 42 columns]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,9 @@ Welcome
 Welcome to the documentation for the Python ``dataretrieval`` package.
 ``dataretrieval`` is a Python alternative to the `USGS R dataRetrieval package`_
 and is used to obtain USGS and EPA water quality data, streamflow data, and
-metadata directly from webservices.
+metadata directly from webservices (see the
+:doc:`data portals documentation </userguide/dataportals>` for additional
+details about specific data sources).
 
 .. _USGS R dataRetrieval package: https://github.com/DOI-USGS/dataRetrieval
 

--- a/docs/source/userguide/dataportals.rst
+++ b/docs/source/userguide/dataportals.rst
@@ -1,0 +1,27 @@
+.. dataportals:
+
+============
+Data Portals
+============
+
+``dataretrieval`` provides a number of functions to retrieve data from several
+data portals, a table listing the portals and corresponding web addresses is
+provided below.
+
++-----------------------------------+---------------------------------------------------------------+
+| Data Portal                       | Uniform Resource Locator (URL)                                |
++===================================+===============================================================+
+| National Water Information System | https://waterdata.usgs.gov/nwis                               |
++-----------------------------------+---------------------------------------------------------------+
+| National Trends Network           | https://nadp.slh.wisc.edu/networks/national-trends-network    |
++-----------------------------------+---------------------------------------------------------------+
+| Mercury Deposition Network        | https://nadp.slh.wisc.edu/networks/mercury-deposition-network |
++-----------------------------------+---------------------------------------------------------------+
+| Streamstats                       | https://streamstats.usgs.gov                                  |
++-----------------------------------+---------------------------------------------------------------+
+| Water Quality Portal              | https://waterqualitydata.us                                   |
++-----------------------------------+---------------------------------------------------------------+
+| WaterWatch                        | https://waterwatch.usgs.gov                                   |
++-----------------------------------+---------------------------------------------------------------+
+| Water Services                    | https://waterservices.usgs.gov                                |
++-----------------------------------+---------------------------------------------------------------+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ ipython
 ipykernel
 nbsphinx
 nbsphinx_link
+matplotlib

--- a/tests/nadp_test.py
+++ b/tests/nadp_test.py
@@ -1,7 +1,10 @@
 """Tests for NADP functions."""
 import pytest
 import os
-import dataretrieval.nadp as nadp
+try:
+    import dataretrieval.nadp as nadp
+except ImportError:
+    pass  # happens when GDAL is not available
 
 
 class TestMDNmap:

--- a/tests/nadp_test.py
+++ b/tests/nadp_test.py
@@ -1,0 +1,59 @@
+"""Tests for NADP functions."""
+import pytest
+import os
+import dataretrieval.nadp as nadp
+
+
+class TestMDNmap:
+    """Testing the mercury deposition network map functions.
+
+    This set of tests actually queries the services themselves to ensure there
+    have been no upstream changes to paths or file names. Tests created
+    because there was an upstream change to paths that broke ``dataretrieval``
+    functionality.
+    """
+
+    @pytest.mark.xfail(reason='This test requires GDAL which is not on the CI runner.')
+    def test_get_annual_MDN_map_zip(self, tmp_path):
+        """Test the get_annual_MDN_map function zip return."""
+        z_path = nadp.get_annual_MDN_map(
+            measurement_type='conc', year='2010', path=tmp_path)
+        exp_path = os.path.join(tmp_path, 'Hg_conc_2010.zip')
+        # assert path matches expectation
+        assert z_path == str(exp_path)
+        # assert unpacked zip exists as a directory
+        assert os.path.exists(exp_path[:-4])
+        # assert tif exists in directory
+        assert os.path.exists(os.path.join(z_path[:-4], 'conc_Hg_2010.tif'))
+
+    @pytest.mark.xfail(reason='This test requires GDAL which is not on the CI runner.')
+    def test_get_annual_MDN_map_buffer(self):
+        """Test the get_annual_MDN_map function buffer return."""
+        gmem = nadp.get_annual_MDN_map(measurement_type='dep', year='2008')
+        # assert gmem is a GDALMemFile object
+        assert isinstance(gmem, nadp.GDALMemFile)
+
+
+class TestNTNmap:
+    """Testing the national trends network map functions."""
+
+    @pytest.mark.xfail(reason='This test requires GDAL which is not on the CI runner.')
+    def test_get_annual_NTN_map_zip(self, tmp_path):
+        """Test the get_annual_NTN_map function zip return."""
+        z_path = nadp.get_annual_NTN_map(
+            measurement_type='Precip', year='2015', path=tmp_path)
+        exp_path = os.path.join(tmp_path, 'Precip_2015.zip')
+        # assert path matches expectation
+        assert z_path == str(exp_path)
+        # assert unpacked zip exists as a directory
+        assert os.path.exists(exp_path[:-4])
+        # assert tif exists in directory
+        assert os.path.exists(os.path.join(z_path[:-4], 'Precip_2015.tif'))
+
+    @pytest.mark.xfail(reason='This test requires GDAL which is not on the CI runner.')
+    def test_get_annual_NTN_map_buffer(self):
+        """Test the get_annual_NTN_map function buffer return."""
+        gmem = nadp.get_annual_NTN_map(
+            measurement_type='conc', measurement='NO3', year='1996')
+        # assert gmem is a GDALMemFile object
+        assert isinstance(gmem, nadp.GDALMemFile)

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -7,7 +7,8 @@ from pandas import DataFrame
 from dataretrieval.wqp import (get_results, what_sites, what_organizations,
                                what_projects, what_activities,
                                what_detection_limits, what_habitat_metrics,
-                               what_project_weights, what_activity_metrics)
+                               what_project_weights, what_activity_metrics,
+                               _alter_kwargs)
 
 
 def test_get_ratings(requests_mock):
@@ -151,3 +152,21 @@ def test_what_activity_metrics(requests_mock):
 def mock_request(requests_mock, request_url, file_path):
     with open(file_path) as text:
         requests_mock.get(request_url, text=text.read(), headers={"mock_header": "value"})
+
+
+class TestAlterKwargs:
+    """Tests for keyword alteration.
+    """
+    def test_alter_kwargs_zip(self):
+        """Tests that zip kwarg is altered correctly and warning is thrown."""
+        kwargs = {"zip": "yes", "mimeType": "csv"}
+        with pytest.warns(UserWarning):
+            kwargs = _alter_kwargs(kwargs)
+        assert kwargs == {"zip": "no", "mimeType": "csv"}
+
+    def test_alter_kwargs_mimetype(self):
+        """Tests that mimetype kwarg is altered correctly and warning is thrown."""
+        kwargs = {"zip": "no", "mimeType": "geojson"}
+        with pytest.warns(UserWarning):
+            kwargs = _alter_kwargs(kwargs)
+        assert kwargs == {"zip": "no", "mimeType": "csv"}


### PR DESCRIPTION
## Improvements to documentation and doc-strings

This looks like a large PR, but it mostly consists of cosmetic changes aimed at improving the rendered documentation and standardizing some of the doc-string and code formatting throughout the package. Given the large size, it might be best to spread the review out over a few days (or weeks) and go through changed files individually due to the number of changes. These changes are summarized below:

### Closing Issues

- Closes #68 by improving the quality of the error message associated with the 414 error message to include a pseudo-code example of splitting up a large query into chunks of some size `n`
- Closes #33 by creating a new page in the documentation with a table of the various data portals ``dataretrieval`` pulls data from and their corresponding URLs
- Closes #46 by adding an example of collecting water use data for a single county in Arizona to the doc-string

### Additional Examples

- Adds at least 1 if not more examples of function usage to the doc-strings of public functions. These will render below the API documentation for a given function, ex:

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/1770513/209858977-865c21b7-f765-4eee-b44f-e0274003df1f.png">

- Adds (and dynamically renders) the hydroshare notebooks put together by @horsburgh - notebooks were downloaded from https://www.hydroshare.org/resource/c97c32ecf59b4dff90ef013030c54264/ - they do not directly reference the notebooks but reference the downloaded copies in the `demos/` subdirectory, it might be possible to pull the latest versions of the notebooks with some fancy CI stuff to download and extract the source notebooks to the proper location every time the documentation workflow is run

### Doc-strings and linting

- PR includes a bunch of edits to standardize the doc-strings to the numpy format. This includes ensuring headers are `Parameters`, `Other Parameters`, `Returns`, and `Examples` exclusively in the doc-strings, as well as explicit inclusion of parameter types
- Some linting to conform to standard PEP-standards for spacing in arguments, line lengths, etc.
- Refer to Python objects in the documentation with double backquotes for Python functions and objects outside of the language, e.g., ``pandas.DataFrame`` whereas for functions that are within the package, the convention :obj:`object` is used, e.g., :obj:`dataretrieval.nwis.get_record` as Sphinx is able to automatically link to the relevant API documentation in that case
- Execute much of the documented code, anything preceded by `.. doctest::` will be run when the documentation is built, some code is preceded by `.. code::` instead because that code is either costly to run (and therefore impractical for the CI job) or requires `gdal` which is not installed on the CI runner at this time

### Code Changes

- Adds a private function `_alter_kwargs` to `wqp.py` to reduce code repetition by using a function to handle the keyword arguments that are not currently supported by `dataretrieval`
- Changes the URLs and paths for `nadp.py` to reflect the current addresses and URL-conventions for the national trends and mercury deposition maps and data

### Unit Tests

- Adds tests for the NADP functions with a `nadp_test.py` file. These tests are marked to `xfail` as the CI runner doesn't have `gdal` installed, but they should pass locally when running the test suite
- Adds unit tests for the new `_alter_kwargs` function within the `wqp_test.py` file