### PR TITLE
Expand site info metadata (addresses #73)

### DIFF
--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -1,9 +1,13 @@
 import numpy as np
 import pandas as pd
 import pytest
+import requests
 import datetime
 from dataretrieval.nwis import get_record, preformat_peaks_response, get_info
 from dataretrieval.nwis import what_sites, get_iv, get_dv, get_discharge_peaks
+from dataretrieval.nwis import _set_metadata
+import unittest.mock as mock
+
 
 START_DATE = '2018-01-24'
 END_DATE   = '2018-01-25'
@@ -201,3 +205,73 @@ def test_empty_timeseries():
     df = get_record(sites='011277906', service='iv',
                     start='2010-07-20', end='2010-07-20')
     assert df.empty is True
+
+
+class TestMetaData:
+    """Tests of NWIS metadata setting, based on GitHub Issue #73."""
+
+    def test_set_metadata_info_site(self):
+        """Test metadata info is set when site parameter is supplied."""
+        # mock the query response
+        response = mock.MagicMock()
+        # make metadata call
+        md = _set_metadata(response, sites='01491000')
+        # assert that metadata info exists but don't execute lambda function
+        assert md.site_info is not None
+        # assert metadata site_info is callable
+        assert hasattr(md.site_info, '__call__')
+
+    def test_set_metadata_info_site_no(self):
+        """Test metadata info is set when site_no parameter is supplied."""
+        # mock the query response
+        response = mock.MagicMock()
+        # make metadata call
+        md = _set_metadata(response, site_no='01491000')
+        # assert that metadata info exists but don't execute lambda function
+        assert md.site_info is not None
+        # assert metadata site_info is callable
+        assert hasattr(md.site_info, '__call__')
+
+    def test_set_metadata_info_stateCd(self):
+        """Test metadata info is set when stateCd parameter is supplied."""
+        # mock the query response
+        response = mock.MagicMock()
+        # make metadata call
+        md = _set_metadata(response, stateCd='RI')
+        # assert that metadata info exists but don't execute lambda function
+        assert md.site_info is not None
+        # assert metadata site_info is callable
+        assert hasattr(md.site_info, '__call__')
+
+    def test_set_metadata_info_huc(self):
+        """Test metadata info is set when huc parameter is supplied."""
+        # mock the query response
+        response = mock.MagicMock()
+        # make metadata call
+        md = _set_metadata(response, huc='01')
+        # assert that metadata info exists but don't execute lambda function
+        assert md.site_info is not None
+        # assert metadata site_info is callable
+        assert hasattr(md.site_info, '__call__')
+
+    def test_set_metadata_info_bbox(self):
+        """Test metadata info is set when bbox parameter is supplied."""
+        # mock the query response
+        response = mock.MagicMock()
+        # make metadata call
+        md = _set_metadata(response, bBox='-92.8,44.2,-88.9,46.0')
+        # assert that metadata info exists but don't execute lambda function
+        assert md.site_info is not None
+        # assert metadata site_info is callable
+        assert hasattr(md.site_info, '__call__')
+
+    def test_set_metadata_info_countyCd(self):
+        """Test metadata info is set when countyCd parameter is supplied."""
+        # mock the query response
+        response = mock.MagicMock()
+        # make metadata call
+        md = _set_metadata(response, countyCd='01001')
+        # assert that metadata info exists but don't execute lambda function
+        assert md.site_info is not None
+        # assert metadata site_info is callable
+        assert hasattr(md.site_info, '__call__')

--- a/tests/waterservices_test.py
+++ b/tests/waterservices_test.py
@@ -29,7 +29,7 @@ def test_query_waterservices_validation():
     """Tests the validation parameters of the query_waterservices method"""
     with pytest.raises(TypeError) as type_error:
         query_waterservices(service='dv', format='rdb')
-    assert 'Query must specify a major filter: sites, stateCd, bBox, or huc' == str(type_error.value)
+    assert 'Query must specify a major filter: sites, stateCd, bBox, huc, or countyCd' == str(type_error.value)
 
     with pytest.raises(TypeError) as type_error:
         query_waterservices(service=None, sites='sites')

--- a/tests/waterservices_test.py
+++ b/tests/waterservices_test.py
@@ -271,9 +271,7 @@ def assert_metadata(requests_mock, request_url, md, site, parameter_cd, format):
     assert md.url == request_url
     assert isinstance(md.query_time, datetime.timedelta)
     assert md.header == {"mock_header": "value"}
-    if site is None:
-        assert md.site_info is None
-    else:
+    if site is not None:
         site_request_url = "https://waterservices.usgs.gov/nwis/site?sites={}&format=rdb".format(site)
         with open('data/waterservices_site.txt') as text:
             requests_mock.get(site_request_url, text=text.read())


### PR DESCRIPTION
This PR closes #73 and fixes bug with `countyCd` queries.

---

Specifically the following changes are proposed:

- Allows water service queries (`query_waterservices`) to be called with only the `countyCd` being specified, previously this was not allowed and made it impossible? to do a county query. Alters error message to match expanded behavior.
- Expands the `_set_metadata` function to allow the `lambda` function assigned to the `site_info` attribute of the metadata object to be set by parameters other than only `sites` and `site_no`
- Adds tests of this expanded `_set_metadata` functionality that do not execute any queries but check that the `lambda` functions behind `metadata.site_info` are set up
- Relaxes metadata check for `site_info` in `waterservices_test.py` as the `site_info` attribute can now be set by more parameters