### PR TITLE
minor fixes for docs

### DIFF
--- a/dataretrieval/nadp.py
+++ b/dataretrieval/nadp.py
@@ -33,10 +33,17 @@ import zipfile
 import io
 import os
 import re
+import warnings
+
 try:
     import gdal
 except:
-    from osgeo import gdal
+    try:
+        from osgeo import gdal
+    except:
+        warnings.warn('GDAL not installed. Some functions will not work.')
+        import mock
+        gdal = mock.MagicMock()
 
 from os.path import basename
 from uuid import uuid4

--- a/docs/source/userguide/index.rst
+++ b/docs/source/userguide/index.rst
@@ -4,6 +4,9 @@
 User Guide
 ==========
 
+Topic guides to provide additional information about various aspects of
+``dataretrieval``.
+
 Contents
 --------
 
@@ -11,6 +14,4 @@ Contents
     :maxdepth: 1
 
     timeconventions
-
-
-.. include:: timeconventions.rst
+    dataportals


### PR DESCRIPTION
fixes 2 things that seem wrong with the documentation

1. `nadp.py` API reference was not rendering because it was not possible for the CI runner to import `gdal` we work around this by returning a warning and then mocking the library if importing fails, this should allow docs to render
2. the new "data portals" documentation page was only accessible via a link from the main documentation page, now it has been added to the "user guide" section so it can be navigated to