### PR TITLE
404 error handling

### DIFF
--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -192,6 +192,10 @@ def query(url, payload, delimiter=','):
 
     if response.status_code == 400:
         raise ValueError("Bad Request, check that your parameters are correct. URL: {}".format(response.url))
+    elif response.status_code == 404:
+        raise ValueError(
+            "Page Not Found Error. May be the result of an empty query. " +
+            f"URL: {response.url}")
     elif response.status_code == 414:
         _reason = response.reason
         _example = """


### PR DESCRIPTION
Closes #78 by throwing an error if the API query return is an HTTP 404 error.

Waiting to merge on discussion in #78, as we are considering switching HTTP errors to throwing warnings with empty dataframes rather than erroring.