### PR TITLE
Defining a user-agent in GET requests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycachr__
 *.so
 
 # Distribution / packaging
-._version.py
+*_version.py
 .Python
 env/
 build/

--- a/dataretrieval/__init__.py
+++ b/dataretrieval/__init__.py
@@ -1,0 +1,7 @@
+from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError
+
+try:
+    __version__ = version('dataretrieval')
+except PackageNotFoundError:
+    __version__ = "version-unknown"

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -161,6 +161,13 @@ def set_metadata(response):
     return md
 
 
+def set_useragent():
+    """Function to define a user-agent to include in the GET query."""
+    _version = "CALL FCT TO GET CURRENT VERSION"
+    user_agent = {'user-agent': f"python-dataretrieval/{_version}"}
+    return user_agent
+
+
 def query(url, payload, delimiter=','):
     """Send a query.
 
@@ -188,7 +195,7 @@ def query(url, payload, delimiter=','):
     #    key, value = payload[index]
     #    payload[index] = (key, to_str(value))
 
-    response = requests.get(url, params=payload)
+    response = requests.get(url, params=payload, header=set_useragent())
 
     if response.status_code == 400:
         raise ValueError("Bad Request, check that your parameters are correct. URL: {}".format(response.url))

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -2,10 +2,9 @@
 Useful utilities for data munging.
 """
 import warnings
-from importlib.metadata import version
-from importlib.metadata import PackageNotFoundError
 import pandas as pd
 import requests
+import dataretrieval
 from dataretrieval.codes import tz
 
 
@@ -163,16 +162,6 @@ def set_metadata(response):
     return md
 
 
-def set_useragent():
-    """Function to define a user-agent to include in the GET query."""
-    try:
-        _version = version('dataretrieval')
-    except PackageNotFoundError:
-        _version = "version-unknown"
-    user_agent = {'user-agent': f"python-dataretrieval/{_version}"}
-    return user_agent
-
-
 def query(url, payload, delimiter=','):
     """Send a query.
 
@@ -200,7 +189,11 @@ def query(url, payload, delimiter=','):
     #    key, value = payload[index]
     #    payload[index] = (key, to_str(value))
 
-    response = requests.get(url, params=payload, headers=set_useragent())
+    # define the user agent for the query
+    user_agent = {
+        'user-agent': f"python-dataretrieval/{dataretrieval.__version__}"}
+
+    response = requests.get(url, params=payload, headers=user_agent)
 
     if response.status_code == 400:
         raise ValueError("Bad Request, check that your parameters are correct. URL: {}".format(response.url))

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -2,9 +2,10 @@
 Useful utilities for data munging.
 """
 import warnings
+from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError
 import pandas as pd
 import requests
-import dataretrieval
 from dataretrieval.codes import tz
 
 
@@ -165,8 +166,8 @@ def set_metadata(response):
 def set_useragent():
     """Function to define a user-agent to include in the GET query."""
     try:
-        _version = dataretrieval.__version__
-    except Exception:
+        _version = version('dataretrieval')
+    except PackageNotFoundError:
         _version = "version-unknown"
     user_agent = {'user-agent': f"python-dataretrieval/{_version}"}
     return user_agent

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -4,6 +4,7 @@ Useful utilities for data munging.
 import warnings
 import pandas as pd
 import requests
+import dataretrieval
 from dataretrieval.codes import tz
 
 
@@ -163,7 +164,10 @@ def set_metadata(response):
 
 def set_useragent():
     """Function to define a user-agent to include in the GET query."""
-    _version = "CALL FCT TO GET CURRENT VERSION"
+    try:
+        _version = dataretrieval.__version__
+    except Exception:
+        _version = "version-unknown"
     user_agent = {'user-agent': f"python-dataretrieval/{_version}"}
     return user_agent
 
@@ -195,7 +199,7 @@ def query(url, payload, delimiter=','):
     #    key, value = payload[index]
     #    payload[index] = (key, to_str(value))
 
-    response = requests.get(url, params=payload, header=set_useragent())
+    response = requests.get(url, params=payload, headers=set_useragent())
 
     if response.status_code == 400:
         raise ValueError("Bad Request, check that your parameters are correct. URL: {}".format(response.url))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,16 @@ import sys
 # path to repository head
 sys.path.insert(0, os.path.abspath('../..'))
 
+import dataretrieval
+try:
+    _version = dataretrieval.__version__
+except Exception:
+    _version = "Unknown"
+
 # Project Information
 project = 'dataretrieval'
-version = '0.7'
-release = '0.7'
+version = _version
+release = _version
 author = 'Hodson et al'
 
 # -- General configuration ------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,20 +8,15 @@
 # Relative paths so documentation can reference and include demos folder
 import os
 import sys
+from importlib.metadata import version
 
 # path to repository head
 sys.path.insert(0, os.path.abspath('../..'))
 
-import dataretrieval
-try:
-    _version = dataretrieval.__version__
-except Exception:
-    _version = "Unknown"
-
 # Project Information
 project = 'dataretrieval'
-version = _version
-release = _version
+release = version(project)
+version = '.'.join(release.split('.')[:2])
 author = 'Hodson et al'
 
 # -- General configuration ------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "dataretrieval"
 description = "Discover and retrieve water data from U.S. federal hydrologic web services."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = ["USGS", "water data"]
 license = {file = "LICENSE.md"}
 maintainers = [

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -31,12 +31,3 @@ class Test_query:
         response = utils.query(url, payload)
         assert response.status_code == 200  # GET was successful
         assert 'user-agent' in response.request.headers
-
-
-def test_useragent():
-    """Test the useragent function."""
-    ua = utils.set_useragent()  # create the user-agent header object
-    # make assertions about it
-    assert isinstance(ua, dict)
-    assert len(ua.keys()) == 1
-    assert ua['user-agent'][:20] == 'python-dataretrieval'

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -19,3 +19,24 @@ class Test_query:
         # raise error by trying to query them all, so URL is way too long
         with pytest.raises(ValueError, match=_msg):
             nwis.get_iv(sites=sites.site_no.values.tolist())
+
+    def test_header(self):
+        """Test checking header info with user-agent is part of query."""
+        url = 'https://waterservices.usgs.gov/nwis/dv'
+        payload = {'format': 'json',
+                   'startDT': '2010-10-01',
+                   'endDT': '2010-10-10',
+                   'sites': '01646500',
+                   'multi_index': True}
+        response = utils.query(url, payload)
+        assert response.status_code == 200  # GET was successful
+        assert 'user-agent' in response.request.headers
+
+
+def test_useragent():
+    """Test the useragent function."""
+    ua = utils.set_useragent()  # create the user-agent header object
+    # make assertions about it
+    assert isinstance(ua, dict)
+    assert len(ua.keys()) == 1
+    assert ua['user-agent'][:20] == 'python-dataretrieval'


### PR DESCRIPTION
Aims to close #83 by adding a string to the header in our HTTP GET requests that identifies the python dataretrieval package and version making the request.

Checked functionality against what the R package does and this follows that convention. The "user-agent" information sent to the server is `python-dataretrieval/<version>` which is consistent with the approach in R.

Wrote some tests for this logic.

---

@thodson-usgs can you confirm that my syntax for getting the current version is correct? We don't currently have a `_version.py` file so in the interest of having the code be more resilient there's currently try-except logic to substitute "version-unknown" when it is not available. But I am hoping that once we do the next release the code `dataretrieval.__version__` will successfully return the version information as a string. Used similar logic to automatically set the versions for the hosted documentation that gets built each time a commit is made.